### PR TITLE
Update source models to v2.33 and downstream models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: tamanu_source_dbt
-version: "2.32.0"
+version: "2.33.0"
 config-version: 2
 
 profile: tamanu_source_dbt
@@ -37,7 +37,7 @@ models:
 
     datasets:
       +docs:
-        show: false
+        show: true
       +materialized: view
       fiji:
         +tags: [fiji]

--- a/models/bases/patient_program_registration_conditions.sql
+++ b/models/bases/patient_program_registration_conditions.sql
@@ -1,12 +1,15 @@
 select
-    id,
-    date::timestamp as datetime,
-    program_registry_condition_id,
-    patient_id,
-    program_registry_id,
-    clinician_id as recorded_by_id,
-    deletion_date::timestamp as deleted_datetime,
-    deletion_clinician_id as deleted_by_id
-from {{ source("tamanu", "patient_program_registration_conditions") }}
-where deleted_at is null
-    and patient_id != '{{ var("test_patient") }}'
+    pprc.id,
+    pprc.date::timestamp as datetime,
+    pprc.program_registry_condition_id,
+    pprc.patient_program_registration_id,
+    pprc.condition_category,
+    pprc.reason_for_change,
+    pprc.clinician_id as recorded_by_id,
+    pprc.deletion_date::timestamp as deleted_datetime,
+    pprc.deletion_clinician_id as deleted_by_id
+from {{ source("tamanu", "patient_program_registration_conditions") }} pprc
+join {{ source("tamanu", "patient_program_registrations") }} ppr
+    on ppr.id = pprc.patient_program_registration_id
+where pprc.deleted_at is null
+    and ppr.patient_id != '{{ var("test_patient") }}'

--- a/models/bases/patient_program_registration_conditions.yml
+++ b/models/bases/patient_program_registration_conditions.yml
@@ -18,16 +18,15 @@ models:
       - name: program_registry_condition_id
         data_type: character varying(255)
         description: "{{ doc('patient_program_registration_conditions__program_registry_condition_id') }}"
-      - name: patient_id
+      - name: patient_program_registration_id
+        data_type: uuid
+        description: "{{ doc('patient_program_registration_conditions__patient_program_registration_id') }}"
+      - name: condition_category
         data_type: character varying(255)
-        description: "{{ doc('patient_program_registration_conditions__patient_id') }}"
-        meta:
-          metrics:
-            total_patients_distinct_count:
-              type: count_distinct
-      - name: program_registry_id
+        description: "{{ doc('patient_program_registration_conditions__condition_category') }}"
+      - name: reason_for_change
         data_type: character varying(255)
-        description: "{{ doc('patient_program_registration_conditions__program_registry_id') }}"
+        description: "{{ doc('patient_program_registration_conditions__reason_for_change') }}"
       - name: recorded_by_id
         data_type: character varying(255)
         description: "{{ doc('patient_program_registration_conditions__clinician_id') }}"

--- a/models/bases/patient_program_registrations.sql
+++ b/models/bases/patient_program_registrations.sql
@@ -9,7 +9,8 @@ select
     registering_facility_id,
     facility_id,
     village_id,
-    is_most_recent
+    deactivated_clinician_id as deactivated_by_id,
+    deactivated_date::timestamp as deactivated_datetime
 from {{ source("tamanu", "patient_program_registrations") }}
 where deleted_at is null
     and patient_id != '{{ var("test_patient") }}'

--- a/models/bases/patient_program_registrations.yml
+++ b/models/bases/patient_program_registrations.yml
@@ -39,6 +39,9 @@ models:
       - name: village_id
         data_type: character varying(255)
         description: "{{ doc('patient_program_registrations__village_id') }}"
-      - name: is_most_recent
-        data_type: boolean
-        description: "{{ doc('patient_program_registrations__is_most_recent') }}"
+      - name: deactivated_by_id
+        data_type: character varying(255)
+        description: "{{ doc('patient_program_registrations__deactivated_clinician_id') }}"
+      - name: deactivated_datetime
+        data_type: timestamp
+        description: "{{ doc('patient_program_registrations__deactivated_date') }}"

--- a/models/datasets/generic/ds__patient_program_registrations.sql
+++ b/models/datasets/generic/ds__patient_program_registrations.sql
@@ -1,7 +1,6 @@
 with related_conditions as (
     select
-        ppr.patient_id,
-        ppr.program_registry_id,
+        ppr.id as patient_program_registration_id,
         string_agg(
             prc.name, '; '
             order by pprc.datetime
@@ -13,7 +12,7 @@ with related_conditions as (
     from {{ ref('patient_program_registration_conditions') }} pprc
     join {{ ref('patient_program_registrations') }} ppr on ppr.id = pprc.patient_program_registration_id
     left join {{ ref('program_registry_conditions') }} prc on prc.id = pprc.program_registry_condition_id
-    group by ppr.patient_id, ppr.program_registry_id
+    group by ppr.id
 )
 
 select
@@ -51,7 +50,7 @@ join {{ ref('users') }} registered_by on registered_by.id = ppr.registered_by_id
 left join {{ ref('reference_data') }} village on village.id = p.village_id
 left join {{ ref('facilities') }} currently_at_facility on currently_at_facility.id = ppr.facility_id
 left join {{ ref('reference_data') }} currently_at_village on currently_at_village.id = ppr.village_id
-left join related_conditions c on (c.patient_id, c.program_registry_id) = (ppr.patient_id, ppr.program_registry_id)
+left join related_conditions c on c.patient_program_registration_id = ppr.id
 left join {{ ref('program_registry_clinical_statuses') }} prcs on prcs.id = ppr.clinical_status_id
 left join {{ ref('users') }} deactivated_by on deactivated_by.id = ppr.deactivated_by_id
 order by ppr.datetime desc

--- a/models/datasets/generic/ds__patient_program_registrations.sql
+++ b/models/datasets/generic/ds__patient_program_registrations.sql
@@ -1,7 +1,7 @@
 with related_conditions as (
     select
-        pprc.patient_id,
-        pprc.program_registry_id,
+        ppr.patient_id,
+        ppr.program_registry_id,
         string_agg(
             prc.name, '; '
             order by pprc.datetime
@@ -11,8 +11,9 @@ with related_conditions as (
             order by pprc.datetime
         ) as condition_ids
     from {{ ref('patient_program_registration_conditions') }} pprc
+    join {{ ref('patient_program_registrations') }} ppr on ppr.id = pprc.patient_program_registration_id
     left join {{ ref('program_registry_conditions') }} prc on prc.id = pprc.program_registry_condition_id
-    group by pprc.program_registry_id, pprc.patient_id
+    group by ppr.patient_id, ppr.program_registry_id
 )
 
 select
@@ -36,10 +37,12 @@ select
     c.conditions as related_conditions,
     prcs.id as clinical_status_id,
     prcs.name as clinical_status,
-    ppr.is_most_recent,
     ppr.registration_status,
     ppr.program_registry_id,
-    ppr.datetime as registration_datetime
+    ppr.datetime as registration_datetime,
+    ppr.deactivated_by_id,
+    deactivated_by.display_name as deactivated_by,
+    ppr.deactivated_datetime
 from {{ ref('patient_program_registrations') }} ppr
 join {{ ref('program_registries') }} pr on pr.id = ppr.program_registry_id
 join {{ ref('patients') }} p on p.id = ppr.patient_id
@@ -50,4 +53,5 @@ left join {{ ref('facilities') }} currently_at_facility on currently_at_facility
 left join {{ ref('reference_data') }} currently_at_village on currently_at_village.id = ppr.village_id
 left join related_conditions c on (c.patient_id, c.program_registry_id) = (ppr.patient_id, ppr.program_registry_id)
 left join {{ ref('program_registry_clinical_statuses') }} prcs on prcs.id = ppr.clinical_status_id
+left join {{ ref('users') }} deactivated_by on deactivated_by.id = ppr.deactivated_by_id
 order by ppr.datetime desc

--- a/models/datasets/generic/ds__patient_program_registrations.yml
+++ b/models/datasets/generic/ds__patient_program_registrations.yml
@@ -3,8 +3,9 @@ version: 2
 models:
   - name: ds__patient_program_registrations
     description: Patient program registrations
-    tags:
-      - clinical
+    config:
+      tags:
+        - clinical
     columns:
       - name: patient_id
         data_type: character varying(255)
@@ -12,10 +13,6 @@ models:
       - name: display_id
         data_type: character varying(255)
         description: "{{ doc('patients__display_id') }}"
-        meta:
-          metrics:
-            total_patients_count:
-              type: count
       - name: first_name
         data_type: character varying(255)
         description: "{{ doc('patients__first_name') }}"

--- a/models/datasets/generic/ds__patient_program_registrations.yml
+++ b/models/datasets/generic/ds__patient_program_registrations.yml
@@ -61,9 +61,6 @@ models:
       - name: clinical_status
         data_type: character varying(255)
         description: "{{ doc('generic__reference_data') }} of the clinical status."
-      - name: is_most_recent
-        data_type: boolean
-        description: "{{ doc('patient_program_registrations__is_most_recent') }}"
       - name: registration_status
         data_type: text
         description: "{{ doc('patient_program_registrations__registration_status') }}"
@@ -73,3 +70,12 @@ models:
       - name: registration_datetime
         data_type: timestamp
         description: "{{ doc('generic__date') }}"
+      - name: deactivated_by_id
+        data_type: character varying(255)
+        description: "{{ doc('patient_program_registrations__deactivated_clinician_id') }}"
+      - name: deactivated_by
+        data_type: character varying(255)
+        description: "{{ doc('generic__user') }} who deactivated the patient program registration."
+      - name: deactivated_datetime
+        data_type: timestamp
+        description: "{{ doc('patient_program_registrations__deactivated_date') }}"

--- a/models/reports/sql/generic/program-registry-line-list.sql
+++ b/models/reports/sql/generic/program-registry-line-list.sql
@@ -13,7 +13,6 @@ select
     registration_datetime as "{{ translate_label('registryRegisteredDate', 'Date of registration') }}"
 from {{ ref('ds__patient_program_registrations') }}
 where registration_status = 'active'
-    and is_most_recent
     and
     case
         when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true

--- a/models/sources/patient_program_registration_conditions.md
+++ b/models/sources/patient_program_registration_conditions.md
@@ -2,15 +2,6 @@
 Table of conditions related to patients in a program registration.
 {% enddocs %}
 
-{% docs patient_program_registration_conditions__patient_id %}
-Reference to the [patient](#!/source/source.tamanu.tamanu.patients).
-{% enddocs %}
-
-{% docs patient_program_registration_conditions__program_registry_id %}
-Reference to the [Program Registry](#!/source/source.tamanu.tamanu.program_registries)
-of the condition.
-{% enddocs %}
-
 {% docs patient_program_registration_conditions__program_registry_condition_id %}
 Reference to the [Program Registry Condition](#!/source/source.tamanu.tamanu.program_registry_conditions).
 {% enddocs %}
@@ -21,4 +12,20 @@ Reference to the [Clinician](#!/source/source.tamanu.tamanu.users) recording tha
 
 {% docs patient_program_registration_conditions__deletion_clinician_id %}
 Reference to the [Clinician](#!/source/source.tamanu.tamanu.users) that removed the condition.
+{% enddocs %}
+
+{% docs patient_program_registration_conditions__condition_category %}
+Used to store the category of the condition.
+{% enddocs %}
+
+{% docs patient_program_registration_conditions__reason_for_change %}
+Optional field for recording the reason for changing the condition.
+{% enddocs %}
+
+{% docs patient_program_registration_conditions__condition %}
+
+{% enddocs %}
+
+{% docs patient_program_registration_conditions__patient_program_registration_id %}
+TODO
 {% enddocs %}

--- a/models/sources/patient_program_registration_conditions.yml
+++ b/models/sources/patient_program_registration_conditions.yml
@@ -42,24 +42,6 @@ sources:
             data_type: character(19)
             description: "{{ doc('generic__deletion_date') }} in
               patient_program_registration_conditions."
-          - name: patient_id
-            data_type: character varying(255)
-            description: "{{ doc('patient_program_registration_conditions__patient_id') }}"
-            data_tests:
-              - not_null
-              - relationships:
-                  to: source('tamanu', 'patients')
-                  field: id
-          - name: program_registry_id
-            data_type: character varying(255)
-            description: "{{
-              doc('patient_program_registration_conditions__program_registry_id\
-              ') }}"
-            data_tests:
-              - not_null
-              - relationships:
-                  to: source('tamanu', 'program_registries')
-                  field: id
           - name: program_registry_condition_id
             data_type: character varying(255)
             description: "{{
@@ -90,5 +72,24 @@ sources:
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
               patient_program_registration_conditions."
+            data_tests:
+              - not_null
+          - name: condition_category
+            data_type: character varying(255)
+            description: "{{
+              doc('patient_program_registration_conditions__condition_category')
+              }}"
+            data_tests:
+              - not_null
+          - name: reason_for_change
+            data_type: character varying(255)
+            description: "{{
+              doc('patient_program_registration_conditions__reason_for_change')
+              }}"
+          - name: patient_program_registration_id
+            data_type: uuid
+            description: "{{
+              doc('patient_program_registration_conditions__patient_program_reg\
+              istration_id') }}"
             data_tests:
               - not_null

--- a/models/sources/patient_program_registrations.md
+++ b/models/sources/patient_program_registrations.md
@@ -53,7 +53,10 @@ Reference to the [Reference Data](#!/source/source.tamanu.tamanu.reference_data)
 (`type=village`) this program registration is from.
 {% enddocs %}
 
-{% docs patient_program_registrations__is_most_recent %}
-A boolean that represents whether this is the most recent registration for this
-specific program registry.
+{% docs patient_program_registrations__deactivated_clinician_id %}
+The clinician that removed the patient from the program registry.
+{% enddocs %}
+
+{% docs patient_program_registrations__deactivated_date %}
+The date that the patient from the program registry.
 {% enddocs %}

--- a/models/sources/patient_program_registrations.yml
+++ b/models/sources/patient_program_registrations.yml
@@ -101,8 +101,10 @@ sources:
               patient_program_registrations."
             data_tests:
               - not_null
-          - name: is_most_recent
-            data_type: boolean
-            description: "{{ doc('patient_program_registrations__is_most_recent') }}"
-            data_tests:
-              - not_null
+          - name: deactivated_clinician_id
+            data_type: character varying(255)
+            description: "{{ doc('patient_program_registrations__deactivated_clinician_id')
+              }}"
+          - name: deactivated_date
+            data_type: character varying(255)
+            description: "{{ doc('patient_program_registrations__deactivated_date') }}"

--- a/models/sources/sync_lookup_ticks.md
+++ b/models/sources/sync_lookup_ticks.md
@@ -1,0 +1,11 @@
+{% docs table__sync_lookup_ticks %}
+Stores range of sync lookup ticks per sync.
+{% enddocs %}
+
+{% docs sync_lookup_ticks__source_start_tick %}
+Represents the previous lookup up to tick.
+{% enddocs %}
+
+{% docs sync_lookup_ticks__lookup_end_tick %}
+Represents the new sync tick at time of updating lookup-pending records.
+{% enddocs %}

--- a/models/sources/sync_lookup_ticks.yml
+++ b/models/sources/sync_lookup_ticks.yml
@@ -1,0 +1,24 @@
+version: 2
+sources:
+  - name: tamanu
+    schema: public
+    description: "{{ doc('generic__schema') }}"
+    tables:
+      - name: sync_lookup_ticks
+        description: '{{ doc("table__sync_lookup_ticks") }}'
+        tags: []
+        columns:
+          - name: id
+            data_type: bigint
+            description: "{{ doc('generic__id') }} in sync_lookup_ticks."
+          - name: source_start_tick
+            data_type: bigint
+            description: "{{ doc('sync_lookup_ticks__source_start_tick') }}"
+            data_tests:
+              - not_null
+          - name: lookup_end_tick
+            data_type: bigint
+            description: "{{ doc('sync_lookup_ticks__lookup_end_tick') }}"
+            data_tests:
+              - unique
+              - not_null

--- a/models/sources/sync_sessions.md
+++ b/models/sources/sync_sessions.md
@@ -22,6 +22,10 @@ Timestamp when sync session snapshot was completed
 Debug information for the sync session
 {% enddocs %}
 
+{% docs sync_sessions__parameters %}
+Parameters for the sync session
+{% enddocs %}
+
 {% docs sync_sessions__completed_at %}
 Timestamp when sync session was completed
 {% enddocs %}

--- a/models/sources/sync_sessions.yml
+++ b/models/sources/sync_sessions.yml
@@ -44,6 +44,11 @@ sources:
           - name: debug_info
             data_type: json
             description: "{{ doc('sync_sessions__debug_info') }}"
+          - name: parameters
+            data_type: jsonb
+            description: "{{ doc('sync_sessions__parameters') }}"
+            data_tests:
+              - not_null
           - name: completed_at
             data_type: timestamp with time zone
             description: "{{ doc('sync_sessions__completed_at') }}"


### PR DESCRIPTION
select count(*) -- 17
from patient_program_registrations
where patient_id != 'h1627394-3778-4c31-a510-9fcb88efdbf3'
	and deleted_at is null

select count(*) -- 17
from reporting.patient_program_registrations

select count(*) --17
from reporting.ds__patient_program_registrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new tracking for deactivation details in patient program registrations, including who deactivated a registration and when.
  - Introduced new fields for condition category and reason for change in patient program registration conditions.
  - Added a new data source and documentation for sync lookup ticks, including details about sync tick ranges.
  - Introduced a new parameters field to sync sessions for enhanced session information.

- **Improvements**
  - Updated queries and schemas to remove reliance on "most recent" flags, providing more detailed deactivation metadata.
  - Enhanced documentation for new and updated fields across patient program registrations, registration conditions, and sync sessions.

- **Bug Fixes**
  - Adjusted queries and data models to align with updated schema, ensuring accurate filtering and data aggregation.

- **Documentation**
  - Added and updated documentation for new fields and sources, improving clarity and transparency for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->