### PR TITLE
fix(encounter-summary): remove invoice data, add village, fix discharge datetimes

### DIFF
--- a/macros/models/encounter_summary.sql
+++ b/macros/models/encounter_summary.sql
@@ -162,7 +162,12 @@ encounter_changes as (
 
         -- Encountering clinician: actor who created the initial encounter record (change_sequence = 1 ensures the creation row is used)
         min(updated_by_id) filter (where change_type is null and change_sequence = 1) as encountering_clinician_id,
-        min(updated_by_name) filter (where change_type is null and change_sequence = 1) as encountering_clinician
+        min(updated_by_name) filter (where change_type is null and change_sequence = 1) as encountering_clinician,
+
+        -- Discharge datetimes: the time the patient was last assigned to each dimension, falls back to encounter start time if never changed
+        to_char(coalesce(max(datetime) filter (where 'department' = any(change_type)), min(datetime) filter (where change_type is null)), '{{ var("datetime_format") }}') as discharge_department_datetime,
+        to_char(coalesce(max(datetime) filter (where 'location' = any(change_type)), min(datetime) filter (where change_type is null)), '{{ var("datetime_format") }}') as discharge_location_datetime,
+        to_char(coalesce(max(datetime) filter (where 'location' = any(change_type) and location_group_id is distinct from prev_location_group_id), min(datetime) filter (where change_type is null)), '{{ var("datetime_format") }}') as discharge_location_group_datetime
     from encounter_history_consolidated
     group by encounter_id
 ),
@@ -185,6 +190,7 @@ encounter_diagnoses as (
         on eis.encounter_id = ed.encounter_id
     join {{ ref('reference_data') }} d
         on d.id = ed.diagnosis_id
+    where ed.certainty not in ('disproven', 'error')
     group by ed.encounter_id
 ),
 
@@ -397,6 +403,7 @@ select
     p.sex as "{{ translate_label('patientSex') }}",
     eth.name as "{{ translate_label('patientEthnicity') }}",
     bt.name as "{{ translate_label('patientBillingType') }}",
+    village.name as "{{ translate_label('patientVillage') }}",
     to_char(eis.start_datetime, '{{ var("datetime_format") }}') as "{{ translate_label('encounterStartDateTime') }}",
     to_char(eis.end_datetime, '{{ var("datetime_format") }}') as "{{ translate_label('encounterEndDateTime') }}",
     case
@@ -429,11 +436,11 @@ select
     ec.encountering_clinician as "{{ translate_label('encounterClinician') }}",
     c.display_name as "{{ translate_label('encounterSupervisingClinician') }}",
     dp.name as "{{ translate_label('dischargeDepartment') }}",
-    ec.department_datetimes[array_upper(ec.department_datetimes, 1)] as "{{ translate_label('dischargeDateTime') }} of {{ translate_label('dischargeDepartment') }}",
+    ec.discharge_department_datetime as "{{ translate_label('dischargeAssignedTime') }} {{ translate_label('dischargeDepartment') }}",
     lg.name as "{{ translate_label('dischargeLocationGroup') }}",
-    ec.location_group_datetimes[array_upper(ec.location_group_datetimes, 1)] as "{{ translate_label('dischargeDateTime') }} of {{ translate_label('dischargeLocationGroup') }}",
+    ec.discharge_location_group_datetime as "{{ translate_label('dischargeAssignedTime') }} {{ translate_label('dischargeLocationGroup') }}",
     l.name as "{{ translate_label('dischargeLocation') }}",
-    ec.location_datetimes[array_upper(ec.location_datetimes, 1)] as "{{ translate_label('dischargeDateTime') }} of {{ translate_label('dischargeLocation') }}",
+    ec.discharge_location_datetime as "{{ translate_label('dischargeAssignedTime') }} {{ translate_label('dischargeLocation') }}",
     ec.departments as "{{ translate_label('encounterDepartmentHistory') }}",
     array_to_string(ec.department_datetimes, ', ') as "{{ translate_label('encounterDepartmentHistoryDateTimes') }}",
     ec.location_groups as "{{ translate_label('encounterLocationGroupHistory') }}",
@@ -476,6 +483,8 @@ left join {{ ref('patient_additional_data') }} pad
     on pad.patient_id = eis.patient_id
 left join {{ ref('reference_data') }} eth
     on eth.id = pad.ethnicity_id
+left join {{ ref('reference_data') }} village
+    on village.id = p.village_id
 left join {{ ref('reference_data') }} bt
     on bt.id = eis.patient_billing_type_id
 left join {{ ref('reference_data') }} am

--- a/macros/models/encounter_summary.sql
+++ b/macros/models/encounter_summary.sql
@@ -386,26 +386,6 @@ encounter_notes as (
     from encounter_notes_deduped n
     where n.row_number = 1
     group by n.record_id
-),
-
-invoice_data as (
-    select
-        i.encounter_id,
-        max(
-            case
-                when i.status = 'finalised'
-                    then to_char(i.datetime, '{{ var("datetime_format") }}')
-            end
-        ) as invoice_finalised_datetime,
-        string_agg(distinct ip.category, ', ') as invoice_product_categories
-    from {{ ref('invoices') }} i
-    join encounters_in_scope eis
-        on eis.encounter_id = i.encounter_id
-    left join {{ ref('invoice_items') }} ii
-        on ii.invoice_id = i.id
-    left join {{ ref('invoice_products') }} ip
-        on ip.id = ii.product_id
-    group by i.encounter_id
 )
 
 select
@@ -474,9 +454,7 @@ select
                 'FULL NOTES HISTORY', '' || E'\n' || '', left(en.notes, 32000)
             )
         else en.notes
-    end as "{{ translate_label('notes') }}",
-    invd.invoice_finalised_datetime as "{{ translate_label('invoiceFinalisedDateTime') }}",
-    invd.invoice_product_categories as "{{ translate_label('invoiceProductCategories') }}"
+    end as "{{ translate_label('notes') }}"
 from encounters_in_scope eis
 join {{ ref('patients') }} p
     on p.id = eis.patient_id
@@ -518,8 +496,6 @@ left join encounter_imaging_requests eir
     on eir.encounter_id = eis.encounter_id
 left join encounter_notes en
     on en.encounter_id = eis.encounter_id
-left join invoice_data invd
-    on invd.encounter_id = eis.encounter_id
 where
     case
         when {{ parameter('departmentId') }} is null then true

--- a/macros/models/encounter_summary.sql
+++ b/macros/models/encounter_summary.sql
@@ -93,43 +93,43 @@ encounter_changes as (
         array_agg(
             to_char(datetime, '{{ var("datetime_format") }}')
             order by datetime
-        ) filter (where change_type isnull or 'location' = any(change_type)) as location_datetimes,
+        ) filter (where change_type is null or 'location' = any(change_type)) as location_datetimes,
         array_agg(
             location_id
             order by datetime
-        ) filter (where change_type isnull or 'location' = any(change_type)) as location_ids,
+        ) filter (where change_type is null or 'location' = any(change_type)) as location_ids,
         string_agg(
             location_name, ', '
             order by datetime
-        ) filter (where change_type isnull or 'location' = any(change_type)) as locations,
+        ) filter (where change_type is null or 'location' = any(change_type)) as locations,
 
         -- Location group changes: tracks location group changes (only when group actually changes)
         array_agg(
             to_char(datetime, '{{ var("datetime_format") }}')
             order by datetime
-        ) filter (where change_type isnull or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_group_datetimes,
+        ) filter (where change_type is null or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_group_datetimes,
         array_agg(
             location_group_id
             order by datetime
-        ) filter (where change_type isnull or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_group_ids,
+        ) filter (where change_type is null or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_group_ids,
         string_agg(
             location_group_name, ', '
             order by datetime
-        ) filter (where change_type isnull or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_groups,
+        ) filter (where change_type is null or ('location' = any(change_type) and location_group_id is distinct from prev_location_group_id)) as location_groups,
 
         -- Department changes: tracks all department changes throughout the encounter
         array_agg(
             to_char(datetime, '{{ var("datetime_format") }}')
             order by datetime
-        ) filter (where change_type isnull or 'department' = any(change_type)) as department_datetimes,
+        ) filter (where change_type is null or 'department' = any(change_type)) as department_datetimes,
         array_agg(
             department_id
             order by datetime
-        ) filter (where change_type isnull or 'department' = any(change_type)) as department_ids,
+        ) filter (where change_type is null or 'department' = any(change_type)) as department_ids,
         string_agg(
             department_name, ', '
             order by datetime
-        ) filter (where change_type isnull or 'department' = any(change_type)) as departments,
+        ) filter (where change_type is null or 'department' = any(change_type)) as departments,
 
         -- Encounter type changes: tracks encounter type progression (emergency types)
         string_agg(
@@ -139,7 +139,7 @@ encounter_changes as (
                 when encounter_type = 'emergency' then 'Emergency short stay'
             end, ', '
             order by datetime
-        ) filter (where change_type isnull or 'encounter_type' = any(change_type)) as encounter_type_emergency,
+        ) filter (where change_type is null or 'encounter_type' = any(change_type)) as encounter_type_emergency,
 
         -- Encounter type changes: tracks encounter type progression (inpatient types)
         string_agg(
@@ -147,7 +147,7 @@ encounter_changes as (
                 when encounter_type = 'admission' then 'Hospital admission'
             end, ', '
             order by datetime
-        ) filter (where change_type isnull or 'encounter_type' = any(change_type)) as encounter_type_inpatient,
+        ) filter (where change_type is null or 'encounter_type' = any(change_type)) as encounter_type_inpatient,
 
         -- Encounter type changes: tracks encounter type progression (outpatient types)
         string_agg(
@@ -158,7 +158,7 @@ encounter_changes as (
                 when encounter_type = 'vaccination' then 'Vaccination'
             end, ', '
             order by datetime
-        ) filter (where change_type isnull or 'encounter_type' = any(change_type)) as encounter_type_outpatient,
+        ) filter (where change_type is null or 'encounter_type' = any(change_type)) as encounter_type_outpatient,
 
         -- Encountering clinician: actor who created the initial encounter record (change_sequence = 1 ensures the creation row is used)
         min(updated_by_id) filter (where change_type is null and change_sequence = 1) as encountering_clinician_id,
@@ -278,7 +278,7 @@ encounter_lab_requests as (
         on ltp.id = ltpr.lab_test_panel_id
     left join {{ ref('lab_tests') }} lt
         on lt.lab_request_id = lr.id
-        and lr.lab_test_panel_request_id isnull
+        and lr.lab_test_panel_request_id is null
     left join {{ ref('lab_test_types') }} ltt
         on ltt.id = lt.lab_test_type_id
     where lr.status not in ('cancelled', 'deleted', 'entered-in-error')

--- a/models/unit_tests/test_encounter_summary_diagnosis_certainty_filter.yml
+++ b/models/unit_tests/test_encounter_summary_diagnosis_certainty_filter.yml
@@ -1,0 +1,223 @@
+unit_tests:
+  - name: test_encounter_summary_excludes_disproven_and_error_diagnoses
+    model: encounter-summary-by-end-date
+    description: >
+      Diagnoses with certainty 'disproven' or 'error' should be excluded from the
+      Diagnoses column. Confirmed and suspected diagnoses should still appear,
+      ordered by is_primary descending then datetime ascending.
+    given:
+      - input: ref('encounters')
+        format: sql
+        rows: |
+          select
+            'enc_001' as id,
+            '2024-01-15 10:00:00'::timestamp as start_datetime,
+            '2024-01-15 14:00:00'::timestamp as end_datetime,
+            'pat_001' as patient_id,
+            'loc_001' as location_id,
+            'dept_001' as department_id,
+            null::text as clinician_id,
+            null::text as patient_billing_type_id,
+            null::text as reason_for_encounter
+
+      - input: ref('encounter_history')
+        format: sql
+        rows: |
+          select
+            'enc_001' as encounter_id,
+            '2024-01-15 10:00:00'::timestamp as datetime,
+            null::text[] as change_type,
+            'user_001' as updated_by_id,
+            'user_001' as clinician_id,
+            'dept_001' as department_id,
+            'loc_001' as location_id,
+            'clinic' as encounter_type
+
+      - input: ref('users')
+        format: sql
+        rows: |
+          select 'user_001' as id, 'Dr. Smith' as display_name
+
+      - input: ref('locations')
+        format: sql
+        rows: |
+          select 'loc_001' as id, 'Ward A' as name, 'fac_001' as facility_id, null::text as location_group_id
+
+      - input: ref('location_groups')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('facilities')
+        format: sql
+        rows: |
+          select 'fac_001' as id, 'General Hospital' as name, false as is_sensitive
+
+      - input: ref('departments')
+        format: sql
+        rows: |
+          select 'dept_001' as id, 'Medicine' as name
+
+      - input: ref('patients')
+        format: sql
+        rows: |
+          select
+            'pat_001' as id,
+            'P001' as display_id,
+            'John' as first_name,
+            'Doe' as last_name,
+            '1990-01-01'::date as date_of_birth,
+            'Male' as sex,
+            null::text as village_id
+
+      - input: ref('patient_additional_data')
+        format: sql
+        rows: |
+          select 'pat_001' as patient_id, null::text as ethnicity_id
+
+      - input: ref('reference_data')
+        format: sql
+        rows: |
+          select 'diag_confirmed' as id, 'Confirmed Disease' as name, 'C01' as code
+          union all
+          select 'diag_suspected', 'Suspected Disease', 'S02'
+          union all
+          select 'diag_disproven', 'Disproven Disease', 'D03'
+          union all
+          select 'diag_error', 'Error Disease', 'E04'
+
+      - input: ref('triages')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::int as score, null::timestamp as triage_datetime, null::timestamp as closed_datetime, null::text as arrival_mode_id where false
+
+      - input: ref('discharges')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as disposition_id where false
+
+      - input: ref('encounter_diagnoses')
+        format: sql
+        rows: |
+          select 'enc_001' as encounter_id, 'diag_confirmed' as diagnosis_id, true as is_primary, 'confirmed' as certainty, '2024-01-15 10:30:00'::timestamp as datetime
+          union all
+          select 'enc_001', 'diag_suspected', false, 'suspected', '2024-01-15 10:45:00'::timestamp
+          union all
+          select 'enc_001', 'diag_disproven', false, 'disproven', '2024-01-15 11:00:00'::timestamp
+          union all
+          select 'enc_001', 'diag_error', false, 'error', '2024-01-15 11:15:00'::timestamp
+
+      - input: ref('encounter_prescriptions')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as prescription_id where false
+
+      - input: ref('prescriptions')
+        format: sql
+        rows: |
+          select null::text as id, null::text as medication_id, null::bool as is_discontinued, null::text as discontinuing_reason, null::timestamp as datetime where false
+
+      - input: ref('vaccine_administrations')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as scheduled_vaccine_id, null::timestamp as datetime where false
+
+      - input: ref('vaccine_schedules')
+        format: sql
+        rows: |
+          select null::text as id, null::text as vaccine_id, null::text as label, null::text as dose_label where false
+
+      - input: ref('procedures')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as procedure_type_id, null::date as date, null::text as location_id, null::text as note, null::text as completed_note where false
+
+      - input: ref('lab_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as lab_test_panel_request_id, null::timestamp as collected_datetime, null::text as status where false
+
+      - input: ref('lab_test_panel_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_test_panel_id where false
+
+      - input: ref('lab_test_panels')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('lab_tests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_request_id, null::text as lab_test_type_id where false
+
+      - input: ref('lab_test_types')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('imaging_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as imaging_type, null::text as status where false
+
+      - input: ref('imaging_request_areas')
+        format: sql
+        rows: |
+          select null::text as imaging_request_id, null::text as area_id where false
+
+      - input: ref('notes')
+        format: sql
+        rows: |
+          select null::text as id, null::timestamp as datetime, null::text as content, null::text as note_type, null::text as record_type, null::text as record_id, null::text as updated_note_id, null::text as visibility_status where false
+
+    expect:
+      format: sql
+      rows: |
+        select
+          'P001' as "Patient ID",
+          'John' as "First name",
+          'Doe' as "Last name",
+          '1990-01-01' as "Date of birth",
+          34 as "Age",
+          'Male' as "Sex",
+          null::text as "Ethnicity",
+          null::text as "Billing type",
+          null::text as "Village",
+          '2024-01-15 10:00:00' as "Encounter start date and time",
+          '2024-01-15 14:00:00' as "Encounter end date and time",
+          1 as "Length of stay (days)",
+          'General Hospital' as "Facility",
+          null::text as "Emergency encounter type",
+          null::text as "Inpatient encounter type",
+          'Clinic' as "Outpatient encounter type",
+          null::text as "Discharge disposition",
+          null::integer as "Triage category",
+          null::text as "Arrival mode",
+          null::text as "Time seen following triage/Waiting time (hh:mm:ss)",
+          'Dr. Smith' as "Clinician",
+          null::text as "Supervising clinician",
+          'Medicine' as "Discharging department",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging department",
+          null::text as "Discharging area",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging area",
+          'Ward A' as "Discharging location",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging location",
+          'Medicine' as "Department history",
+          '2024-01-15 10:00:00' as "Department history date and times",
+          null::text as "Area history",
+          '2024-01-15 10:00:00' as "Area history date and times",
+          'Ward A' as "Location history",
+          '2024-01-15 10:00:00' as "Location history date and times",
+          null::text as "Reason for encounter",
+          'Name: Confirmed Disease, Code: C01, Is primary: primary, Certainty: confirmed'
+          || E'\n' ||
+          'Name: Suspected Disease, Code: S02, Is primary: secondary, Certainty: suspected'
+          as "Diagnoses",
+          null::text as "Medications",
+          null::text as "Vaccinations",
+          null::text as "Procedures",
+          null::text as "Lab requests",
+          null::text as "Imaging requests",
+          null::text as "Notes"

--- a/models/unit_tests/test_encounter_summary_discharge_datetime_fallback.yml
+++ b/models/unit_tests/test_encounter_summary_discharge_datetime_fallback.yml
@@ -1,0 +1,208 @@
+unit_tests:
+  - name: test_enc_summary_discharge_datetime_fallback
+    model: encounter-summary-by-end-date
+    description: >
+      When an encounter has no location, department, or area changes (only the initial
+      encounter_history creation record with change_type = null), the discharge assigned
+      time columns should fall back to the encounter start datetime rather than null.
+    given:
+      - input: ref('encounters')
+        format: sql
+        rows: |
+          select
+            'enc_001' as id,
+            '2024-01-15 10:00:00'::timestamp as start_datetime,
+            '2024-01-15 14:00:00'::timestamp as end_datetime,
+            'pat_001' as patient_id,
+            'loc_001' as location_id,
+            'dept_001' as department_id,
+            null::text as clinician_id,
+            null::text as patient_billing_type_id,
+            null::text as reason_for_encounter
+
+      - input: ref('encounter_history')
+        format: sql
+        rows: |
+          select
+            'enc_001' as encounter_id,
+            '2024-01-15 10:00:00'::timestamp as datetime,
+            null::text[] as change_type,
+            'user_001' as updated_by_id,
+            'user_001' as clinician_id,
+            'dept_001' as department_id,
+            'loc_001' as location_id,
+            'clinic' as encounter_type
+
+      - input: ref('users')
+        format: sql
+        rows: |
+          select 'user_001' as id, 'Dr. Smith' as display_name
+
+      - input: ref('locations')
+        format: sql
+        rows: |
+          select 'loc_001' as id, 'Ward A' as name, 'fac_001' as facility_id, null::text as location_group_id
+
+      - input: ref('location_groups')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('facilities')
+        format: sql
+        rows: |
+          select 'fac_001' as id, 'General Hospital' as name, false as is_sensitive
+
+      - input: ref('departments')
+        format: sql
+        rows: |
+          select 'dept_001' as id, 'Medicine' as name
+
+      - input: ref('patients')
+        format: sql
+        rows: |
+          select
+            'pat_001' as id,
+            'P001' as display_id,
+            'John' as first_name,
+            'Doe' as last_name,
+            '1990-01-01'::date as date_of_birth,
+            'Male' as sex,
+            null::text as village_id
+
+      - input: ref('patient_additional_data')
+        format: sql
+        rows: |
+          select 'pat_001' as patient_id, null::text as ethnicity_id
+
+      - input: ref('reference_data')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name, null::text as code where false
+
+      - input: ref('triages')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::int as score, null::timestamp as triage_datetime, null::timestamp as closed_datetime, null::text as arrival_mode_id where false
+
+      - input: ref('discharges')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as disposition_id where false
+
+      - input: ref('encounter_diagnoses')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as diagnosis_id, null::bool as is_primary, null::text as certainty, null::timestamp as datetime where false
+
+      - input: ref('encounter_prescriptions')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as prescription_id where false
+
+      - input: ref('prescriptions')
+        format: sql
+        rows: |
+          select null::text as id, null::text as medication_id, null::bool as is_discontinued, null::text as discontinuing_reason, null::timestamp as datetime where false
+
+      - input: ref('vaccine_administrations')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as scheduled_vaccine_id, null::timestamp as datetime where false
+
+      - input: ref('vaccine_schedules')
+        format: sql
+        rows: |
+          select null::text as id, null::text as vaccine_id, null::text as label, null::text as dose_label where false
+
+      - input: ref('procedures')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as procedure_type_id, null::date as date, null::text as location_id, null::text as note, null::text as completed_note where false
+
+      - input: ref('lab_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as lab_test_panel_request_id, null::timestamp as collected_datetime, null::text as status where false
+
+      - input: ref('lab_test_panel_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_test_panel_id where false
+
+      - input: ref('lab_test_panels')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('lab_tests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_request_id, null::text as lab_test_type_id where false
+
+      - input: ref('lab_test_types')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('imaging_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as imaging_type, null::text as status where false
+
+      - input: ref('imaging_request_areas')
+        format: sql
+        rows: |
+          select null::text as imaging_request_id, null::text as area_id where false
+
+      - input: ref('notes')
+        format: sql
+        rows: |
+          select null::text as id, null::timestamp as datetime, null::text as content, null::text as note_type, null::text as record_type, null::text as record_id, null::text as updated_note_id, null::text as visibility_status where false
+
+    expect:
+      format: sql
+      rows: |
+        select
+          'P001' as "Patient ID",
+          'John' as "First name",
+          'Doe' as "Last name",
+          '1990-01-01' as "Date of birth",
+          34 as "Age",
+          'Male' as "Sex",
+          null::text as "Ethnicity",
+          null::text as "Billing type",
+          null::text as "Village",
+          '2024-01-15 10:00:00' as "Encounter start date and time",
+          '2024-01-15 14:00:00' as "Encounter end date and time",
+          1 as "Length of stay (days)",
+          'General Hospital' as "Facility",
+          null::text as "Emergency encounter type",
+          null::text as "Inpatient encounter type",
+          'Clinic' as "Outpatient encounter type",
+          null::text as "Discharge disposition",
+          null::integer as "Triage category",
+          null::text as "Arrival mode",
+          null::text as "Time seen following triage/Waiting time (hh:mm:ss)",
+          'Dr. Smith' as "Clinician",
+          null::text as "Supervising clinician",
+          'Medicine' as "Discharging department",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging department",
+          null::text as "Discharging area",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging area",
+          'Ward A' as "Discharging location",
+          '2024-01-15 10:00:00' as "Time assigned to Discharging location",
+          'Medicine' as "Department history",
+          '2024-01-15 10:00:00' as "Department history date and times",
+          null::text as "Area history",
+          '2024-01-15 10:00:00' as "Area history date and times",
+          'Ward A' as "Location history",
+          '2024-01-15 10:00:00' as "Location history date and times",
+          null::text as "Reason for encounter",
+          null::text as "Diagnoses",
+          null::text as "Medications",
+          null::text as "Vaccinations",
+          null::text as "Procedures",
+          null::text as "Lab requests",
+          null::text as "Imaging requests",
+          null::text as "Notes"

--- a/models/unit_tests/test_encounter_summary_discharge_datetime_with_changes.yml
+++ b/models/unit_tests/test_encounter_summary_discharge_datetime_with_changes.yml
@@ -1,0 +1,209 @@
+unit_tests:
+  - name: test_enc_summary_discharge_datetime_with_changes
+    model: encounter-summary-by-end-date
+    description: >
+      When an encounter has actual department and location changes in encounter_history,
+      the discharge assigned time columns should reflect the time of the last change for
+      each dimension, not the encounter start time. This tests the primary path where
+      max(datetime) filter is used instead of the fallback to start time.
+    given:
+      - input: ref('encounters')
+        format: sql
+        rows: |
+          select
+            'enc_001' as id,
+            '2024-01-15 10:00:00'::timestamp as start_datetime,
+            '2024-01-15 14:00:00'::timestamp as end_datetime,
+            'pat_001' as patient_id,
+            'loc_002' as location_id,
+            'dept_002' as department_id,
+            null::text as clinician_id,
+            null::text as patient_billing_type_id,
+            null::text as reason_for_encounter
+
+      - input: ref('encounter_history')
+        format: sql
+        rows: |
+          select 'enc_001' as encounter_id, '2024-01-15 10:00:00'::timestamp as datetime, null::text[] as change_type, 'user_001' as updated_by_id, 'user_001' as clinician_id, 'dept_001' as department_id, 'loc_001' as location_id, 'clinic' as encounter_type
+          union all
+          select 'enc_001', '2024-01-15 11:30:00'::timestamp, array['department']::text[], 'user_001', 'user_001', 'dept_002', 'loc_001', 'clinic'
+          union all
+          select 'enc_001', '2024-01-15 12:00:00'::timestamp, array['location']::text[], 'user_001', 'user_001', 'dept_002', 'loc_002', 'clinic'
+
+      - input: ref('users')
+        format: sql
+        rows: |
+          select 'user_001' as id, 'Dr. Smith' as display_name
+
+      - input: ref('locations')
+        format: sql
+        rows: |
+          select 'loc_001' as id, 'Ward A' as name, 'fac_001' as facility_id, null::text as location_group_id
+          union all
+          select 'loc_002', 'Ward B', 'fac_001', 'lg_001'
+
+      - input: ref('location_groups')
+        format: sql
+        rows: |
+          select 'lg_001' as id, 'ICU' as name
+
+      - input: ref('facilities')
+        format: sql
+        rows: |
+          select 'fac_001' as id, 'General Hospital' as name, false as is_sensitive
+
+      - input: ref('departments')
+        format: sql
+        rows: |
+          select 'dept_001' as id, 'General Medicine' as name
+          union all
+          select 'dept_002', 'Cardiology'
+
+      - input: ref('patients')
+        format: sql
+        rows: |
+          select
+            'pat_001' as id,
+            'P001' as display_id,
+            'John' as first_name,
+            'Doe' as last_name,
+            '1990-01-01'::date as date_of_birth,
+            'Male' as sex,
+            null::text as village_id
+
+      - input: ref('patient_additional_data')
+        format: sql
+        rows: |
+          select 'pat_001' as patient_id, null::text as ethnicity_id
+
+      - input: ref('reference_data')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name, null::text as code where false
+
+      - input: ref('triages')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::int as score, null::timestamp as triage_datetime, null::timestamp as closed_datetime, null::text as arrival_mode_id where false
+
+      - input: ref('discharges')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as disposition_id where false
+
+      - input: ref('encounter_diagnoses')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as diagnosis_id, null::bool as is_primary, null::text as certainty, null::timestamp as datetime where false
+
+      - input: ref('encounter_prescriptions')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as prescription_id where false
+
+      - input: ref('prescriptions')
+        format: sql
+        rows: |
+          select null::text as id, null::text as medication_id, null::bool as is_discontinued, null::text as discontinuing_reason, null::timestamp as datetime where false
+
+      - input: ref('vaccine_administrations')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as scheduled_vaccine_id, null::timestamp as datetime where false
+
+      - input: ref('vaccine_schedules')
+        format: sql
+        rows: |
+          select null::text as id, null::text as vaccine_id, null::text as label, null::text as dose_label where false
+
+      - input: ref('procedures')
+        format: sql
+        rows: |
+          select null::text as encounter_id, null::text as procedure_type_id, null::date as date, null::text as location_id, null::text as note, null::text as completed_note where false
+
+      - input: ref('lab_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as lab_test_panel_request_id, null::timestamp as collected_datetime, null::text as status where false
+
+      - input: ref('lab_test_panel_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_test_panel_id where false
+
+      - input: ref('lab_test_panels')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('lab_tests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as lab_request_id, null::text as lab_test_type_id where false
+
+      - input: ref('lab_test_types')
+        format: sql
+        rows: |
+          select null::text as id, null::text as name where false
+
+      - input: ref('imaging_requests')
+        format: sql
+        rows: |
+          select null::text as id, null::text as encounter_id, null::text as imaging_type, null::text as status where false
+
+      - input: ref('imaging_request_areas')
+        format: sql
+        rows: |
+          select null::text as imaging_request_id, null::text as area_id where false
+
+      - input: ref('notes')
+        format: sql
+        rows: |
+          select null::text as id, null::timestamp as datetime, null::text as content, null::text as note_type, null::text as record_type, null::text as record_id, null::text as updated_note_id, null::text as visibility_status where false
+
+    expect:
+      format: sql
+      rows: |
+        select
+          'P001' as "Patient ID",
+          'John' as "First name",
+          'Doe' as "Last name",
+          '1990-01-01' as "Date of birth",
+          34 as "Age",
+          'Male' as "Sex",
+          null::text as "Ethnicity",
+          null::text as "Billing type",
+          null::text as "Village",
+          '2024-01-15 10:00:00' as "Encounter start date and time",
+          '2024-01-15 14:00:00' as "Encounter end date and time",
+          1 as "Length of stay (days)",
+          'General Hospital' as "Facility",
+          null::text as "Emergency encounter type",
+          null::text as "Inpatient encounter type",
+          'Clinic' as "Outpatient encounter type",
+          null::text as "Discharge disposition",
+          null::integer as "Triage category",
+          null::text as "Arrival mode",
+          null::text as "Time seen following triage/Waiting time (hh:mm:ss)",
+          'Dr. Smith' as "Clinician",
+          null::text as "Supervising clinician",
+          'Cardiology' as "Discharging department",
+          '2024-01-15 11:30:00' as "Time assigned to Discharging department",
+          'ICU' as "Discharging area",
+          '2024-01-15 12:00:00' as "Time assigned to Discharging area",
+          'Ward B' as "Discharging location",
+          '2024-01-15 12:00:00' as "Time assigned to Discharging location",
+          'General Medicine, Cardiology' as "Department history",
+          '2024-01-15 10:00:00, 2024-01-15 11:30:00' as "Department history date and times",
+          'ICU' as "Area history",
+          '2024-01-15 10:00:00, 2024-01-15 12:00:00' as "Area history date and times",
+          'Ward A, Ward B' as "Location history",
+          '2024-01-15 10:00:00, 2024-01-15 12:00:00' as "Location history date and times",
+          null::text as "Reason for encounter",
+          null::text as "Diagnoses",
+          null::text as "Medications",
+          null::text as "Vaccinations",
+          null::text as "Procedures",
+          null::text as "Lab requests",
+          null::text as "Imaging requests",
+          null::text as "Notes"

--- a/report_translations_standard.csv
+++ b/report_translations_standard.csv
@@ -140,12 +140,6 @@ report.reporting.imagingTotalRequests,Total new requests
 report.reporting.imagingType,Imaging type
 report.reporting.insurerId,Insurer ID
 report.reporting.insurerName,Name of insurer
-report.reporting.invoiceInsurerAmount,Total insurer amount
-report.reporting.invoiceInsurers,Insurer
-report.reporting.invoiceInsurerTotal,Insurer total
-report.reporting.invoiceNumber,Invoice number
-report.reporting.invoicePatientAmount,Total patient amount
-report.reporting.invoicePatientDiscount,Total patient discount
 report.reporting.invoiceProductCategory,Category
 report.reporting.invoiceProductCategoryId,Category ID
 report.reporting.invoiceProductId,ID
@@ -153,9 +147,6 @@ report.reporting.invoiceProductInsurable,Insurable
 report.reporting.invoiceProductName,Product name
 report.reporting.invoiceProductLabExternalCode,Lab external code
 report.reporting.invoiceProductVisibilityStatus,Visibility status
-report.reporting.invoiceRemainingInsurerBalance,Remaining balance (insurer payments)
-report.reporting.invoiceRemainingPatientBalance,Remaining balance (patient)
-report.reporting.invoiceTotalAmount,Total invoice amount
 report.reporting.labLaboratory,Laboratory
 report.reporting.labRequestCancellationReason,Reason for cancellation
 report.reporting.labRequestClinician,Requesting clinician

--- a/report_translations_standard.csv
+++ b/report_translations_standard.csv
@@ -86,6 +86,7 @@ report.reporting.diagnosisCertainty,Certainty
 report.reporting.diagnosisDateTime,Date & time
 report.reporting.diagnosisIsPrimary,Is primary
 report.reporting.dischargeDate,Discharged date
+report.reporting.dischargeAssignedTime,Time assigned to
 report.reporting.dischargeDateTime,Discharge date and time
 report.reporting.dischargeDepartment,Discharging department
 report.reporting.dischargeDisposition,Discharge disposition


### PR DESCRIPTION
- Remove invoice_data CTE and invoice columns (invoiceFinalisedDateTime, invoiceProductCategories)
- Fix discharge assigned time columns: use last change datetime per dimension (coalesce to start time) instead of array_upper which incorrectly returned start time when no changes existed
- Rename column label from dischargeDateTime to dischargeAssignedTime
- Add patientVillage column
- Exclude disproven/error diagnoses (align with tamanu-db-reports behaviour)
- Remove unused invoice translation labels