### PR TITLE
feat(seeds): add central cohort definitions registry

### DIFF
--- a/seeds/cohort_definitions.csv
+++ b/seeds/cohort_definitions.csv
@@ -1,0 +1,2 @@
+cohort_definition_id,cohort_name,description,omop_concept_id,vocabulary_id
+1,ncd_registry,Non-communicable disease program registry (hypertension and/or diabetes),4214956,SNOMED

--- a/seeds/cohort_definitions.yml
+++ b/seeds/cohort_definitions.yml
@@ -1,0 +1,26 @@
+version: 2
+
+seeds:
+  - name: cohort_definitions
+    description: >
+      Central registry of cohort definitions across all BES deployments.
+      Authoritative source of `cohort_definition_id` values — never assign
+      an ID locally in a deployment repo. Open a PR here to register a new
+      cohort before building deployment-specific `coh__` models.
+    columns:
+      - name: cohort_definition_id
+        description: Unique integer ID assigned sequentially. Never reused.
+        tests:
+          - not_null
+          - unique
+      - name: cohort_name
+        description: Short machine-readable name (e.g. `ncd_registry`).
+        tests:
+          - not_null
+          - unique
+      - name: description
+        description: Human-readable description of the cohort program.
+      - name: omop_concept_id
+        description: OMOP concept ID for the clinical domain (SNOMED preferred).
+      - name: vocabulary_id
+        description: Vocabulary source (e.g. `SNOMED`).


### PR DESCRIPTION
## Summary

- Introduces `seeds/cohort_definitions.csv` as the authoritative source of `cohort_definition_id` values across all BES deployments
- Deployment-specific `coh__` models must reference IDs from this registry — never assign one locally
- Adds `seeds/cohort_definitions.yml` with schema documentation and `not_null` / `unique` tests on the primary key
- Seeds the registry with `cohort_definition_id = 1` for the NCD program registry

This supports the OMOP-inspired cohort conventions introduced in the `.maui` submodule (see [maui-team #10](https://github.com/beyondessential/maui-team/pull/10)).

## Test plan

- [ ] `dbt seed --profiles-dir config --select cohort_definitions` runs without error
- [ ] `dbt test --profiles-dir config --select cohort_definitions` passes (`not_null`, `unique`)
- [ ] Review NCD registry entry — confirm `omop_concept_id` 4214956 (SNOMED: Non-communicable disease) is appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)