### PR TITLE
ci: add dbt tests workflow

### DIFF
--- a/.github/workflows/dbt-tests.yml
+++ b/.github/workflows/dbt-tests.yml
@@ -1,0 +1,12 @@
+name: dbt Tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    uses: beyondessential/maui-team/.github/workflows/dbt-tests.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds caller workflow for the reusable `dbt-tests.yml` from `maui-team`
- Runs `dbt test` against a live database on PRs and pushes to main
- Requires `DBT_HOST`, `DBT_DBNAME`, `DBT_USER`, and `DBT_PASSWORD` repository secrets to be configured
- Target schema defaults to `reporting` (override via `dbt-schema` input)

## Test plan
- [ ] Verify required secrets are configured in repo settings
- [ ] Open a test PR to confirm the workflow triggers and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)