### PR TITLE
revert(ci): use kubectl port-forward to CNPG primary for reporting assets build

### DIFF
--- a/.github/workflows/build-reporting-assets.yml
+++ b/.github/workflows/build-reporting-assets.yml
@@ -52,7 +52,6 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "namespace=tamanu-release-${MINOR_VERSION//./-}" >> "$GITHUB_OUTPUT"
-          echo "db_host=k8s-pg-release-${MINOR_VERSION//./-}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,24 +87,38 @@ jobs:
         run: |
           NS="${{ steps.version.outputs.namespace }}"
 
-          DB_HOST="${{ steps.version.outputs.db_host }}"
-
           pgpass=$(kubectl get -n "$NS" secrets central-db-app -o jsonpath='{.data.password}' | base64 -d)
           echo "::add-mask::$pgpass"
 
-          for i in $(seq 1 10); do
-            if pg_isready -h "$DB_HOST" -p 5432 -q; then
+          primary=$(kubectl get pods -n "$NS" -l cnpg.io/cluster=central-db,role=primary -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$primary" ]; then
+            echo "::error::No primary pod found for central-db in namespace $NS"
+            exit 1
+          fi
+          echo "Port-forwarding to primary pod: $primary"
+          kubectl port-forward -n "$NS" "pod/$primary" 5432:5432 &
+          pf_pid=$!
+          function cleanup() { kill "$pf_pid" 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
+              echo "Port-forward ready"
               break
             fi
-            if [ "$i" -eq 10 ]; then
-              echo "::error::Database not reachable at $DB_HOST:5432 after 30s"
+            if ! kill -0 "$pf_pid" 2>/dev/null; then
+              echo "::error::Port-forward process died"
               exit 1
             fi
-            echo "Waiting for database at $DB_HOST:5432 (attempt $i/10)..."
-            sleep 3
+            sleep 1
           done
 
-          TAMANU_RL_DB_URL="$DB_HOST" \
+          if ! pg_isready -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
+            echo "::error::Port-forward not ready after 30s"
+            exit 1
+          fi
+
+          TAMANU_RL_DB_URL=127.0.0.1 \
           TAMANU_RL_DB_PORT=5432 \
           TAMANU_RL_DB_USER=app \
           TAMANU_RL_DB_PASSWORD="$pgpass" \

--- a/.github/workflows/build-reporting-assets.yml
+++ b/.github/workflows/build-reporting-assets.yml
@@ -96,7 +96,7 @@ jobs:
             exit 1
           fi
           echo "Port-forwarding to primary pod: $primary"
-          kubectl port-forward -n "$NS" "pod/$primary" 5432:5432 &
+          kubectl port-forward -n "$NS" "pod/$primary" 5432:5432 >/tmp/pf.log 2>&1 &
           pf_pid=$!
           function cleanup() { kill "$pf_pid" 2>/dev/null || true; }
           trap cleanup EXIT
@@ -108,6 +108,8 @@ jobs:
             fi
             if ! kill -0 "$pf_pid" 2>/dev/null; then
               echo "::error::Port-forward process died"
+              echo "--- kubectl port-forward output ---"
+              cat /tmp/pf.log
               exit 1
             fi
             sleep 1
@@ -115,6 +117,8 @@ jobs:
 
           if ! pg_isready -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
             echo "::error::Port-forward not ready after 30s"
+            echo "--- kubectl port-forward output ---"
+            cat /tmp/pf.log
             exit 1
           fi
 

--- a/.github/workflows/build-reporting-assets.yml
+++ b/.github/workflows/build-reporting-assets.yml
@@ -95,6 +95,8 @@ jobs:
             echo "::error::No primary pod found for central-db in namespace $NS"
             exit 1
           fi
+          # Pinned to the primary pod (not service/central-db-rw) so reads are guaranteed
+          # to hit the writeable instance; trade-off is no failover during the build.
           echo "Port-forwarding to primary pod: $primary"
           kubectl port-forward -n "$NS" "pod/$primary" 5432:5432 >/tmp/pf.log 2>&1 &
           pf_pid=$!


### PR DESCRIPTION
## Summary
This PR updates the build-reporting-assets workflow to connect to the PostgreSQL database via kubectl port-forwarding instead of directly accessing a database host. This change improves reliability and removes the need to maintain a separate database hostname configuration.

## Key Changes
- Removed hardcoded `db_host` output from the version step that constructed a database hostname
- Replaced direct database host connectivity with kubectl port-forwarding to the primary database pod
- Updated database connection logic to:
  - Query for the primary pod using CloudNativePG selectors (`cnpg.io/cluster=central-db,role=primary`)
  - Establish a port-forward tunnel from localhost:5432 to the pod's 5432 port
  - Implement proper cleanup of the port-forward process on exit
- Changed database readiness checks from 10 attempts (30s total) to 30 attempts (30s total) with 1s intervals
- Updated connection string to use `127.0.0.1` instead of the external database hostname
- Added error handling for missing primary pods and port-forward process failures

## Implementation Details
- The port-forward process is managed with a cleanup trap to ensure it's terminated when the workflow step completes
- Added validation to ensure a primary pod exists before attempting to establish the port-forward
- Improved error messages to distinguish between pod discovery failures and port-forward connectivity issues

https://claude.ai/code/session_01Lqd7EK7wcoqfNE7T9yehZ3