### PR TITLE
refactor(reports): remove unnecessary null checks on fromDate and toDate parameters

### DIFF
--- a/macros/models/encounter_summary.sql
+++ b/macros/models/encounter_summary.sql
@@ -24,14 +24,8 @@ with encounters_in_scope as (
         {% if date_field == 'end_datetime' %}
         and e.end_datetime is not null
         {% endif %}
-        and case
-            when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-            else {{ to_user_selected_timezone('e.' ~ date_field) }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-        end
-        and case
-            when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-            else {{ to_user_selected_timezone('e.' ~ date_field) }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-        end
+        and {{ to_user_selected_timezone('e.' ~ date_field) }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+        and {{ to_user_selected_timezone('e.' ~ date_field) }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
         and case
             when {{ parameter('facilityId') }} is null then true
             else f.id = {{ parameter('facilityId') }}

--- a/models/reports/sql/sensitive/sensitive-admissions-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-admissions-line-list.sql
@@ -22,12 +22,8 @@ select
     secondary_diagnoses as "{{ translate_label('diagnosesSecondary') }}"
 from {{ ref('ds__sensitive_admissions') }}
 where
-    case when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('admission_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
-    and case when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('admission_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('admission_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('admission_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('locationGroupId') }} is null then true
         else {{ parameter('locationGroupId') }} = any(location_group_ids::text [])
     end

--- a/models/reports/sql/sensitive/sensitive-audit-outpatient-appointments-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-audit-outpatient-appointments-line-list.sql
@@ -30,15 +30,9 @@ select
 from {{ ref('ds__sensitive_outpatient_appointments_audit') }}
 where
     -- Date range filter on appointment datetime
-    case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
     -- Facility filter
     and
     case

--- a/models/reports/sql/sensitive/sensitive-encounter-diets-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-encounter-diets-line-list.sql
@@ -14,15 +14,9 @@ where
         else ed.location_group_id = {{ parameter('locationGroupId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('ed.start_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('ed.start_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('ed.start_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('ed.start_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by ed.location_group, ed.location, ed.patient_name

--- a/models/reports/sql/sensitive/sensitive-imaging-requests-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-imaging-requests-line-list.sql
@@ -20,17 +20,11 @@ select
     to_char({{ to_user_selected_timezone('completed_datetime') }}, '{{ var("datetime_format") }}') as "{{ translate_label('imagingCompletedDateTime') }}",
     reason_for_cancellation as "{{ translate_label('imagingCancellationReason') }}"
 from {{ ref('ds__sensitive_imaging_requests') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('requestedById') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-incomplete-referrals.sql
+++ b/models/reports/sql/sensitive/sensitive-incomplete-referrals.sql
@@ -9,17 +9,11 @@ select
     department as "{{ translate_label('department') }}"
 from {{ ref('ds__sensitive_referrals') }}
 where status in ('pending', 'cancelled')
-    and case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('referral_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    and {{ to_user_selected_timezone('referral_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('referral_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('referral_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('doctorId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-lab-requests-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-lab-requests-line-list.sql
@@ -41,15 +41,9 @@ where case
         else status_id = {{ parameter('statusId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by requested_datetime, last_name, first_name, tests

--- a/models/reports/sql/sensitive/sensitive-lab-tests-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-lab-tests-line-list.sql
@@ -24,17 +24,11 @@ select
     lab_test_type as "{{ translate_label('labTestType') }}",
     to_char({{ to_user_selected_timezone('lab_test_completed_datetime') }}, '{{ var("datetime_format") }}') as "{{ translate_label('labTestCompletedDateTime') }}"
 from {{ ref('ds__sensitive_lab_tests') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('statusId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-location-bookings-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-location-bookings-line-list.sql
@@ -22,15 +22,9 @@ select
     booking_type as "{{ translate_label('bookingType') }}",
     booking_status as "{{ translate_label('bookingStatus') }}"
 from {{ ref('ds__sensitive_location_bookings') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('booking_start_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('booking_start_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('booking_end_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('booking_end_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('locationGroupId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-medication-dispensed-summary.sql
+++ b/models/reports/sql/sensitive/sensitive-medication-dispensed-summary.sql
@@ -14,15 +14,9 @@ where
         else md.medication_id = {{ parameter('medicationId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }} is null then true
-        else {{ to_user_selected_timezone('md.dispensed_at') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }}
-    end
+    {{ to_user_selected_timezone('md.dispensed_at') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }} is null then true
-        else {{ to_user_selected_timezone('md.dispensed_at') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }}
-    end
+    {{ to_user_selected_timezone('md.dispensed_at') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }}
 group by md.medication_id, md.medication, md.medication_code

--- a/models/reports/sql/sensitive/sensitive-outpatient-appointments-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-outpatient-appointments-line-list.sql
@@ -22,15 +22,8 @@ select
     to_char(until_date, '{{ var("date_format") }}') as "{{ translate_label('appointmentRepeatingEndDate') }}",
     created_by as "{{ translate_label('appointmentCreatedBy') }}"
 from {{ ref('ds__sensitive_outpatient_appointments') }}
-where case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
-    and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
     and
     case
         when {{ parameter('locationGroupId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-patient-emergency-encounters-summary.sql
+++ b/models/reports/sql/sensitive/sensitive-patient-emergency-encounters-summary.sql
@@ -12,16 +12,8 @@ where case
         when {{ parameter('patientId') }} is null then true
         else patient_id = {{ parameter('patientId') }}
     end
-    and
-    case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('triage_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
-    and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('triage_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    and {{ to_user_selected_timezone('triage_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('triage_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
 group by
     display_id,
     first_name,

--- a/models/reports/sql/sensitive/sensitive-prescription-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-prescription-line-list.sql
@@ -22,12 +22,8 @@ select
     frequency as "{{ translate_label('prescriptionFrequency') }}"
 from {{ ref('ds__sensitive_encounter_prescriptions') }}
 where
-    case when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
-    and case when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('facilityId') }} is null then true
         else {{ parameter('facilityId') }} = facility_id
     end

--- a/models/reports/sql/sensitive/sensitive-procedures-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-procedures-line-list.sql
@@ -27,17 +27,11 @@ select
     time_out as "{{ translate_label('procedureTimeOut') }}"
 from {{ ref('ds__sensitive_procedures') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else procedure_date
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    procedure_date
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else procedure_date
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    procedure_date
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('facilityId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-recent-diagnoses-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-recent-diagnoses-line-list.sql
@@ -14,17 +14,11 @@ select
     is_primary as "{{ translate_label('diagnosisIsPrimary') }}"
 from {{ ref('ds__sensitive_diagnoses') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('diagnosis_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('diagnosis_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('diagnosis_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('diagnosis_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('facilityId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-user-audit-report.sql
+++ b/models/reports/sql/sensitive/sensitive-user-audit-report.sql
@@ -16,17 +16,11 @@ select
     non_discharge_by_clinicians as "{{ translate_label('encounterNonDischargeClinician') }}"
 from {{ ref('ds__sensitive_user_audit') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('encounter_start_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('encounter_start_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('encounter_start_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('encounter_start_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('departmentId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-vaccine-audit-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-vaccine-audit-line-list.sql
@@ -20,17 +20,11 @@ from {{ ref("ds__sensitive_vaccinations") }}
 where
     vaccine_status in ('Recorded in error', 'Historical')
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('villageId') }} is null then true

--- a/models/reports/sql/sensitive/sensitive-vaccine-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-vaccine-line-list.sql
@@ -28,17 +28,11 @@ from {{ ref("ds__sensitive_vaccinations") }}
 where
     vaccine_status in ('Given', 'Not Given')
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('villageId') }} is null then true

--- a/models/reports/sql/standard/admissions-line-list.sql
+++ b/models/reports/sql/standard/admissions-line-list.sql
@@ -22,12 +22,8 @@ select
     secondary_diagnoses as "{{ translate_label('diagnosesSecondary') }}"
 from {{ ref('ds__admissions') }}
 where
-    case when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('admission_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
-    and case when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('admission_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('admission_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('admission_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('locationGroupId') }} is null then true
         else {{ parameter('locationGroupId') }} = any(location_group_ids::text [])
     end

--- a/models/reports/sql/standard/audit-outpatient-appointments-line-list.sql
+++ b/models/reports/sql/standard/audit-outpatient-appointments-line-list.sql
@@ -30,15 +30,9 @@ select
 from {{ ref('ds__outpatient_appointments_audit') }}
 where
     -- Date range filter on appointment datetime
-    case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
     -- Facility filter
     and
     case

--- a/models/reports/sql/standard/audit-patient-details-edits-line-list.sql
+++ b/models/reports/sql/standard/audit-patient-details-edits-line-list.sql
@@ -11,15 +11,9 @@ select
     to_char({{ to_user_selected_timezone('edited_datetime') }}, '{{ var("datetime_without_seconds_format") }}') as "{{ translate_label('logChangeDateTime') }}"
 from {{ ref('ds__patients_change_logs') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('edited_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('edited_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('edited_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('edited_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('patientId') }} is null then true

--- a/models/reports/sql/standard/audit-patient-views-line-list.sql
+++ b/models/reports/sql/standard/audit-patient-views-line-list.sql
@@ -13,15 +13,9 @@ select
     to_char({{ to_user_selected_timezone('date_time_viewed') }}, '{{ var("datetime_without_seconds_format") }}') as "{{ translate_label('logAccessDatetime') }}"
 from {{ ref('ds__patients_access_logs') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('date_time_viewed') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('date_time_viewed') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('date_time_viewed') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('date_time_viewed') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('patientId') }} is null then true

--- a/models/reports/sql/standard/deceased-patients-line-list.sql
+++ b/models/reports/sql/standard/deceased-patients-line-list.sql
@@ -38,16 +38,8 @@ select
     death_within_day_of_birth as "{{ translate_label('deathWithinDayOfBirth') }}",
     hours_survived_since_birth as "{{ translate_label('deathHoursSurvivedSinceBirth') }}"
 from {{ ref('ds__deaths') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null
-            then true
-        else date_of_death >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
-    and case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null
-            then true
-        else date_of_death <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+where date_of_death >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+    and date_of_death <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case
         when {{ parameter('causeOfDeath') }} is null
             then true

--- a/models/reports/sql/standard/encounter-diets-line-list.sql
+++ b/models/reports/sql/standard/encounter-diets-line-list.sql
@@ -14,15 +14,9 @@ where
         else ed.location_group_id = {{ parameter('locationGroupId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('ed.start_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('ed.start_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('ed.start_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('ed.start_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by ed.location_group, ed.location, ed.patient_name

--- a/models/reports/sql/standard/imaging-requests-line-list.sql
+++ b/models/reports/sql/standard/imaging-requests-line-list.sql
@@ -20,17 +20,11 @@ select
     to_char({{ to_user_selected_timezone('completed_datetime') }}, '{{ var("datetime_format") }}') as "{{ translate_label('imagingCompletedDateTime') }}",
     reason_for_cancellation as "{{ translate_label('imagingCancellationReason') }}"
 from {{ ref('ds__imaging_requests') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('requestedById') }} is null then true

--- a/models/reports/sql/standard/incomplete-referrals.sql
+++ b/models/reports/sql/standard/incomplete-referrals.sql
@@ -9,17 +9,11 @@ select
     department as "{{ translate_label('department') }}"
 from {{ ref('ds__referrals') }}
 where status in ('pending', 'cancelled')
-    and case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('referral_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    and {{ to_user_selected_timezone('referral_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('referral_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('referral_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('doctorId') }} is null then true

--- a/models/reports/sql/standard/lab-requests-line-list.sql
+++ b/models/reports/sql/standard/lab-requests-line-list.sql
@@ -40,15 +40,9 @@ where case
         else status_id = {{ parameter('statusId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by requested_datetime, last_name, first_name, tests

--- a/models/reports/sql/standard/lab-tests-line-list.sql
+++ b/models/reports/sql/standard/lab-tests-line-list.sql
@@ -23,17 +23,11 @@ select
     lab_test_type as "{{ translate_label('labTestType') }}",
     to_char({{ to_user_selected_timezone('lab_test_completed_datetime') }}, '{{ var("datetime_format") }}') as "{{ translate_label('labTestCompletedDateTime') }}"
 from {{ ref('ds__lab_tests') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('requested_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('requested_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('requested_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('statusId') }} is null then true

--- a/models/reports/sql/standard/location-bookings-line-list.sql
+++ b/models/reports/sql/standard/location-bookings-line-list.sql
@@ -22,15 +22,9 @@ select
     booking_type as "{{ translate_label('bookingType') }}",
     booking_status as "{{ translate_label('bookingStatus') }}"
 from {{ ref('ds__location_bookings') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('booking_start_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('booking_start_datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('booking_end_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('booking_end_datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('locationGroupId') }} is null then true

--- a/models/reports/sql/standard/medication-dispensed-summary.sql
+++ b/models/reports/sql/standard/medication-dispensed-summary.sql
@@ -14,15 +14,9 @@ where
         else md.medication_id = {{ parameter('medicationId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }} is null then true
-        else {{ to_user_selected_timezone('md.dispensed_at') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }}
-    end
+    {{ to_user_selected_timezone('md.dispensed_at') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='timestamp') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }} is null then true
-        else {{ to_user_selected_timezone('md.dispensed_at') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }}
-    end
+    {{ to_user_selected_timezone('md.dispensed_at') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='timestamp') }}
 group by md.medication_id, md.medication, md.medication_code

--- a/models/reports/sql/standard/ongoing-conditions-line-list.sql
+++ b/models/reports/sql/standard/ongoing-conditions-line-list.sql
@@ -12,15 +12,9 @@ select
     to_char(date_resolved, '{{ var("date_format") }}') as "{{ translate_label('conditionResolvedDate') }}",
     clinician_resolving as "{{ translate_label('conditionResolvedBy') }}"
 from {{ ref('ds__ongoing_conditions') }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('recorded_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('recorded_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('recorded_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('recorded_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by recorded_datetime

--- a/models/reports/sql/standard/outpatient-appointments-line-list.sql
+++ b/models/reports/sql/standard/outpatient-appointments-line-list.sql
@@ -22,15 +22,9 @@ select
     to_char(until_date, '{{ var("date_format") }}') as "{{ translate_label('appointmentRepeatingEndDate') }}",
     created_by as "{{ translate_label('appointmentCreatedBy') }}"
 from {{ ref('ds__outpatient_appointments') }}
-where case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
+where {{ to_user_selected_timezone('appointment_start_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('appointment_start_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
     and
     case
         when {{ parameter('locationGroupId') }} is null then true

--- a/models/reports/sql/standard/patient-emergency-encounters-summary.sql
+++ b/models/reports/sql/standard/patient-emergency-encounters-summary.sql
@@ -13,15 +13,9 @@ where case
         else patient_id = {{ parameter('patientId') }}
     end
     and
-    case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('triage_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('triage_datetime') }} >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('triage_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('triage_datetime') }} <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
 group by
     display_id,
     first_name,

--- a/models/reports/sql/standard/prescription-line-list.sql
+++ b/models/reports/sql/standard/prescription-line-list.sql
@@ -22,12 +22,8 @@ select
     frequency as "{{ translate_label('prescriptionFrequency') }}"
 from {{ ref('ds__encounter_prescriptions') }}
 where
-    case when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
-    and case when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
+    and {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('facilityId') }} is null then true
         else {{ parameter('facilityId') }} = facility_id
     end

--- a/models/reports/sql/standard/procedures-line-list.sql
+++ b/models/reports/sql/standard/procedures-line-list.sql
@@ -27,17 +27,11 @@ select
     time_out as "{{ translate_label('procedureTimeOut') }}"
 from {{ ref('ds__procedures') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else procedure_date
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    procedure_date
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else procedure_date
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    procedure_date
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('facilityId') }} is null then true

--- a/models/reports/sql/standard/program-registry-line-list.sql
+++ b/models/reports/sql/standard/program-registry-line-list.sql
@@ -17,17 +17,11 @@ select
 from {{ ref('ds__patient_program_registrations') }}
 where registration_status = 'active'
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('registration_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('registration_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('registration_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('registration_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('registryId') }} is null then true

--- a/models/reports/sql/standard/program-registry-removed-patients-line-list.sql
+++ b/models/reports/sql/standard/program-registry-removed-patients-line-list.sql
@@ -17,17 +17,11 @@ select
 from {{ ref('ds__patient_program_registrations') }}
 where registration_status != 'active'
     and
-    case
-        when {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('deactivated_datetime') }}
-            >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('deactivated_datetime') }}
+        >= {{ parameter('fromDate', default_value='2025-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2025-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('deactivated_datetime') }}
-            <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('deactivated_datetime') }}
+        <= {{ parameter('toDate', default_value='2025-01-31', data_type='date') }}
     and
     case
         when {{ parameter('registryId') }} is null then true

--- a/models/reports/sql/standard/recent-diagnoses-line-list.sql
+++ b/models/reports/sql/standard/recent-diagnoses-line-list.sql
@@ -14,17 +14,11 @@ select
     is_primary as "{{ translate_label('diagnosisIsPrimary') }}"
 from {{ ref('ds__diagnoses') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('diagnosis_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('diagnosis_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('diagnosis_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('diagnosis_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('facilityId') }} is null then true

--- a/models/reports/sql/standard/registered-births-line-list.sql
+++ b/models/reports/sql/standard/registered-births-line-list.sql
@@ -26,15 +26,9 @@ select
     apgar_score_ten_minutes as "{{ translate_label('birthApgarScoreTenMinutes') }}"
 from {{ ref("ds__births") }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('villageId') }} is null then true

--- a/models/reports/sql/standard/registered-patients-by-dob-line-list.sql
+++ b/models/reports/sql/standard/registered-patients-by-dob-line-list.sql
@@ -25,13 +25,7 @@ select
     religion as "{{ translate_label('patientReligion') }}",
     patient_billing_type as "{{ translate_label('patientBillingType') }}"
 from {{ ref("ds__patients") }}
-where case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+where date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by date_of_birth, last_name, first_name

--- a/models/reports/sql/standard/registered-patients-daily-summary.sql
+++ b/models/reports/sql/standard/registered-patients-daily-summary.sql
@@ -8,13 +8,7 @@ select
     ) as "{{ translate_label('patientFemaleCount') }}"
 from {{ ref("ds__patients") }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 group by registration_date

--- a/models/reports/sql/standard/registered-patients-line-list.sql
+++ b/models/reports/sql/standard/registered-patients-line-list.sql
@@ -27,13 +27,7 @@ select
     division as "{{ translate_label('patientDivision') }}"
 from {{ ref("ds__patients") }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
 order by registration_date

--- a/models/reports/sql/standard/upcoming-vaccinations-line-list.sql
+++ b/models/reports/sql/standard/upcoming-vaccinations-line-list.sql
@@ -12,15 +12,9 @@ select
     vaccine_status as "{{ translate_label('vaccinationStatus') }}"
 from {{ ref("ds__patient_vaccinations_upcoming") }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    date_of_birth >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    date_of_birth <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('status') }} is null then true

--- a/models/reports/sql/standard/usage-quality-metrics-patient-registrations.sql
+++ b/models/reports/sql/standard/usage-quality-metrics-patient-registrations.sql
@@ -5,12 +5,6 @@ select
     total_incorrect_registrations_for_patient_under_6mth as "{{ translate_label('patientTotalIncorrectRegistrationsForAgedUnder6Months') }}"
 from {{ ref("ds__usage_quality_metrics_patient_registrations") }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    registration_date >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    registration_date <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}

--- a/models/reports/sql/standard/user-audit-report.sql
+++ b/models/reports/sql/standard/user-audit-report.sql
@@ -16,17 +16,11 @@ select
     non_discharge_by_clinicians as "{{ translate_label('encounterNonDischargeClinician') }}"
 from {{ ref('ds__user_audit') }}
 where
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('encounter_start_datetime') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('encounter_start_datetime') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('encounter_start_datetime') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('encounter_start_datetime') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('departmentId') }} is null then true

--- a/models/reports/sql/standard/vaccine-audit-line-list.sql
+++ b/models/reports/sql/standard/vaccine-audit-line-list.sql
@@ -20,17 +20,11 @@ from {{ ref("ds__vaccinations") }}
 where
     vaccine_status in ('Recorded in error', 'Historical')
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('villageId') }} is null then true

--- a/models/reports/sql/standard/vaccine-line-list.sql
+++ b/models/reports/sql/standard/vaccine-line-list.sql
@@ -28,17 +28,11 @@ from {{ ref("ds__vaccinations") }}
 where
     vaccine_status in ('Given', 'Not Given')
     and
-    case
-        when {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and
-    case
-        when {{ parameter('toDate', default_value='2024-01-31', data_type='date') }} is null then true
-        else {{ to_user_selected_timezone('vaccination_date') }}
-            <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
-    end
+    {{ to_user_selected_timezone('vaccination_date') }}
+        <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and
     case
         when {{ parameter('villageId') }} is null then true


### PR DESCRIPTION
## Summary
- Remove `case when ... is null then true else ... end` wrappers around `fromDate` and `toDate` parameter checks across 47 files (29 standard reports, 17 sensitive reports, 1 macro)
- Since `fromDate` and `toDate` parameters can never be null, these guards are dead code — replaced with direct `>=` / `<=` comparisons
- All other parameter null checks (e.g. `facilityId`, `locationGroupId`, `clinicianId`) are preserved as they can be null

## Test plan
- [ ] Verify reports compile with `dbt compile`
- [ ] Spot-check a sample of reports with date range filters to confirm correct filtering behaviour
- [ ] Confirm no `fromDate`/`toDate` null checks remain: `grep -r "fromDate.*is null\|toDate.*is null" models/reports/ macros/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)