### PR TITLE
chore(metadata): remove tier field from model YAML files

### DIFF
--- a/models/bases/contributing_death_causes.yml
+++ b/models/bases/contributing_death_causes.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/departments.yml
+++ b/models/bases/departments.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/discharges.yml
+++ b/models/bases/discharges.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/document_metadata.yml
+++ b/models/bases/document_metadata.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/encounter_diagnoses.yml
+++ b/models/bases/encounter_diagnoses.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/encounter_diagnoses_metadata.yml
+++ b/models/bases/encounter_diagnoses_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/encounter_diets.yml
+++ b/models/bases/encounter_diets.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/encounter_history.yml
+++ b/models/bases/encounter_history.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/encounter_prescriptions.yml
+++ b/models/bases/encounter_prescriptions.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/encounters.yml
+++ b/models/bases/encounters.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/encounters_metadata.yml
+++ b/models/bases/encounters_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/facilities.yml
+++ b/models/bases/facilities.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/imaging_area_external_codes.yml
+++ b/models/bases/imaging_area_external_codes.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/imaging_request_areas.yml
+++ b/models/bases/imaging_request_areas.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/imaging_requests.yml
+++ b/models/bases/imaging_requests.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/imaging_results.yml
+++ b/models/bases/imaging_results.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/invoice_discounts.yml
+++ b/models/bases/invoice_discounts.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoice_insurance_plan_items.yml
+++ b/models/bases/invoice_insurance_plan_items.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/invoice_insurance_plans.yml
+++ b/models/bases/invoice_insurance_plans.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/invoice_insurer_payments.yml
+++ b/models/bases/invoice_insurer_payments.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoice_item_discounts.yml
+++ b/models/bases/invoice_item_discounts.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoice_item_finalised_insurances.yml
+++ b/models/bases/invoice_item_finalised_insurances.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoice_items.yml
+++ b/models/bases/invoice_items.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoice_patient_payments.yml
+++ b/models/bases/invoice_patient_payments.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/invoice_payments.yml
+++ b/models/bases/invoice_payments.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/invoice_price_list_items.yml
+++ b/models/bases/invoice_price_list_items.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/invoice_price_lists.yml
+++ b/models/bases/invoice_price_lists.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/invoice_products.yml
+++ b/models/bases/invoice_products.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/invoices.yml
+++ b/models/bases/invoices.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/invoices_change_logs.yml
+++ b/models/bases/invoices_change_logs.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/invoices_invoice_insurance_plans.yml
+++ b/models/bases/invoices_invoice_insurance_plans.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/lab_request_logs.yml
+++ b/models/bases/lab_request_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/lab_request_logs_metadata.yml
+++ b/models/bases/lab_request_logs_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/lab_requests.yml
+++ b/models/bases/lab_requests.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/lab_requests_metadata.yml
+++ b/models/bases/lab_requests_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/lab_test_panel_lab_test_types.yml
+++ b/models/bases/lab_test_panel_lab_test_types.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/lab_test_panel_requests.yml
+++ b/models/bases/lab_test_panel_requests.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/lab_test_panels.yml
+++ b/models/bases/lab_test_panels.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/lab_test_types.yml
+++ b/models/bases/lab_test_types.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/lab_tests.yml
+++ b/models/bases/lab_tests.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/location_bookings.yml
+++ b/models/bases/location_bookings.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/location_groups.yml
+++ b/models/bases/location_groups.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/locations.yml
+++ b/models/bases/locations.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/medication_dispenses.yml
+++ b/models/bases/medication_dispenses.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/notes.yml
+++ b/models/bases/notes.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/outpatient_appointments.yml
+++ b/models/bases/outpatient_appointments.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/outpatient_appointments_change_logs.yml
+++ b/models/bases/outpatient_appointments_change_logs.yml
@@ -14,7 +14,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_additional_data.yml
+++ b/models/bases/patient_additional_data.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/patient_additional_data_change_logs.yml
+++ b/models/bases/patient_additional_data_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/patient_allergies.yml
+++ b/models/bases/patient_allergies.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_birth_data.yml
+++ b/models/bases/patient_birth_data.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_care_plans.yml
+++ b/models/bases/patient_care_plans.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_conditions.yml
+++ b/models/bases/patient_conditions.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_death_contributing_causes.yml
+++ b/models/bases/patient_death_contributing_causes.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_death_data.yml
+++ b/models/bases/patient_death_data.yml
@@ -7,7 +7,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_facilities.yml
+++ b/models/bases/patient_facilities.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_family_histories.yml
+++ b/models/bases/patient_family_histories.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_field_values.yml
+++ b/models/bases/patient_field_values.yml
@@ -7,7 +7,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/patient_program_registration_conditions.yml
+++ b/models/bases/patient_program_registration_conditions.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_program_registration_conditions_change_logs.yml
+++ b/models/bases/patient_program_registration_conditions_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_program_registrations.yml
+++ b/models/bases/patient_program_registrations.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_program_registrations_change_logs.yml
+++ b/models/bases/patient_program_registrations_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patient_vaccinations_upcoming.yml
+++ b/models/bases/patient_vaccinations_upcoming.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/patients.yml
+++ b/models/bases/patients.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/patients_access_logs.yml
+++ b/models/bases/patients_access_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/patients_change_logs.yml
+++ b/models/bases/patients_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/patients_merged.yml
+++ b/models/bases/patients_merged.yml
@@ -8,7 +8,6 @@ models:
   meta:
     owner: bes-maui
     domain: clinical
-    tier: silver
     pii: true
     classification: restricted
   columns:

--- a/models/bases/patients_metadata.yml
+++ b/models/bases/patients_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/pharmacy_order_prescriptions.yml
+++ b/models/bases/pharmacy_order_prescriptions.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/pharmacy_orders.yml
+++ b/models/bases/pharmacy_orders.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/prescriptions.yml
+++ b/models/bases/prescriptions.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/procedures.yml
+++ b/models/bases/procedures.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/procedures_metadata.yml
+++ b/models/bases/procedures_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/program_data_elements.yml
+++ b/models/bases/program_data_elements.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/program_registries.yml
+++ b/models/bases/program_registries.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/program_registry_clinical_statuses.yml
+++ b/models/bases/program_registry_clinical_statuses.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/program_registry_condition_categories.yml
+++ b/models/bases/program_registry_condition_categories.yml
@@ -7,7 +7,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/program_registry_conditions.yml
+++ b/models/bases/program_registry_conditions.yml
@@ -7,7 +7,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/programs.yml
+++ b/models/bases/programs.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/reference_data.yml
+++ b/models/bases/reference_data.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/referrals.yml
+++ b/models/bases/referrals.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/refresh_tokens.yml
+++ b/models/bases/refresh_tokens.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/roles.yml
+++ b/models/bases/roles.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/survey_response_answers.yml
+++ b/models/bases/survey_response_answers.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/survey_responses.yml
+++ b/models/bases/survey_responses.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/survey_screen_components.yml
+++ b/models/bases/survey_screen_components.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/surveys.yml
+++ b/models/bases/surveys.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: internal
     columns:

--- a/models/bases/triages.yml
+++ b/models/bases/triages.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/users.yml
+++ b/models/bases/users.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: true
       classification: restricted
     columns:

--- a/models/bases/users_metadata.yml
+++ b/models/bases/users_metadata.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: silver
       pii: false
       classification: confidential
     columns:

--- a/models/bases/vaccine_administrations.yml
+++ b/models/bases/vaccine_administrations.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/vaccine_administrations_change_logs.yml
+++ b/models/bases/vaccine_administrations_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/bases/vaccine_schedules.yml
+++ b/models/bases/vaccine_schedules.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: silver
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__births.yml
+++ b/models/datasets/admin/ds__births.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__deaths.yml
+++ b/models/datasets/admin/ds__deaths.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__invoice_products.yml
+++ b/models/datasets/admin/ds__invoice_products.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: gold
       pii: false
       classification: internal
     columns:

--- a/models/datasets/admin/ds__ongoing_conditions.yml
+++ b/models/datasets/admin/ds__ongoing_conditions.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__patient_program_registrations.yml
+++ b/models/datasets/admin/ds__patient_program_registrations.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__patient_vaccinations_upcoming.yml
+++ b/models/datasets/admin/ds__patient_vaccinations_upcoming.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__patients.yml
+++ b/models/datasets/admin/ds__patients.yml
@@ -8,7 +8,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__patients_access_logs.yml
+++ b/models/datasets/admin/ds__patients_access_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__patients_change_logs.yml
+++ b/models/datasets/admin/ds__patients_change_logs.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__usage_quality_metrics_patient_details.yml
+++ b/models/datasets/admin/ds__usage_quality_metrics_patient_details.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/admin/ds__usage_quality_metrics_patient_registrations.yml
+++ b/models/datasets/admin/ds__usage_quality_metrics_patient_registrations.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_admissions.yml
+++ b/models/datasets/sensitive/ds__sensitive_admissions.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_diagnoses.yml
+++ b/models/datasets/sensitive/ds__sensitive_diagnoses.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_encounter_diets.yml
+++ b/models/datasets/sensitive/ds__sensitive_encounter_diets.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_encounter_prescriptions.yml
+++ b/models/datasets/sensitive/ds__sensitive_encounter_prescriptions.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_encounters_emergency.yml
+++ b/models/datasets/sensitive/ds__sensitive_encounters_emergency.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_imaging_requests.yml
+++ b/models/datasets/sensitive/ds__sensitive_imaging_requests.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_lab_requests.yml
+++ b/models/datasets/sensitive/ds__sensitive_lab_requests.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_lab_tests.yml
+++ b/models/datasets/sensitive/ds__sensitive_lab_tests.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_location_bookings.yml
+++ b/models/datasets/sensitive/ds__sensitive_location_bookings.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_medication_dispenses.yml
+++ b/models/datasets/sensitive/ds__sensitive_medication_dispenses.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_outpatient_appointments.yml
+++ b/models/datasets/sensitive/ds__sensitive_outpatient_appointments.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_outpatient_appointments_audit.yml
+++ b/models/datasets/sensitive/ds__sensitive_outpatient_appointments_audit.yml
@@ -15,7 +15,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_procedures.yml
+++ b/models/datasets/sensitive/ds__sensitive_procedures.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_referrals.yml
+++ b/models/datasets/sensitive/ds__sensitive_referrals.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_user_audit.yml
+++ b/models/datasets/sensitive/ds__sensitive_user_audit.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/sensitive/ds__sensitive_vaccinations.yml
+++ b/models/datasets/sensitive/ds__sensitive_vaccinations.yml
@@ -10,7 +10,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__admissions.yml
+++ b/models/datasets/standard/ds__admissions.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__diagnoses.yml
+++ b/models/datasets/standard/ds__diagnoses.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__encounter_diets.yml
+++ b/models/datasets/standard/ds__encounter_diets.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__encounter_prescriptions.yml
+++ b/models/datasets/standard/ds__encounter_prescriptions.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__encounters_emergency.yml
+++ b/models/datasets/standard/ds__encounters_emergency.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__imaging_requests.yml
+++ b/models/datasets/standard/ds__imaging_requests.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__lab_requests.yml
+++ b/models/datasets/standard/ds__lab_requests.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__lab_tests.yml
+++ b/models/datasets/standard/ds__lab_tests.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__location_bookings.yml
+++ b/models/datasets/standard/ds__location_bookings.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__medication_dispenses.yml
+++ b/models/datasets/standard/ds__medication_dispenses.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: false
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__outpatient_appointments.yml
+++ b/models/datasets/standard/ds__outpatient_appointments.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__outpatient_appointments_audit.yml
+++ b/models/datasets/standard/ds__outpatient_appointments_audit.yml
@@ -14,7 +14,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__procedures.yml
+++ b/models/datasets/standard/ds__procedures.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__referrals.yml
+++ b/models/datasets/standard/ds__referrals.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:

--- a/models/datasets/standard/ds__user_audit.yml
+++ b/models/datasets/standard/ds__user_audit.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: admin
-      tier: gold
       pii: false
       classification: confidential
     columns:

--- a/models/datasets/standard/ds__vaccinations.yml
+++ b/models/datasets/standard/ds__vaccinations.yml
@@ -9,7 +9,6 @@ models:
     meta:
       owner: bes-maui
       domain: clinical
-      tier: gold
       pii: true
       classification: restricted
     columns:


### PR DESCRIPTION
## Summary

Mechanical cleanup: strip the legacy `tier:` meta field from 136 model YAML files (`models/bases/*.yml`, `models/datasets/**/*.yml`).

Per `.maui/knowledge/standards/dbt-metadata.md`:

> Readiness is encoded by the layer prefix... no separate `tier` field.

The codebase has been carrying `tier: silver` / `tier: gold` / `tier: bronze` on most models even though the field is no longer specified by the convention. This PR brings every existing model into alignment.

## Linear / spec

No Linear issue — surfaced during MAUI-6642 review when an unrelated audit-report YAML carried the same legacy field.

## What's in this PR

- One line removed per file across 136 YAMLs.
- No semantic changes. `tier:` was never queried by dbt, scripts, or consumers — it was advisory metadata that has since been replaced by the layer-prefix convention (`base__`, `ref__`, `ds__`, etc.).
- `compiled/` snapshots intentionally left alone — they are auto-generated historical artefacts and will pick up the cleaned state on next regeneration.

## Test plan

- [x] `python scripts/validate_report_configs.py` — unaffected (passes)
- [x] `python scripts/check_translations.py` — unaffected (passes)
- [ ] `dbt parse --profiles-dir config` — confirms YAML still parses cleanly (run in maintainer env)

## Risk / rollback

**Very low.** Field was unused. Each diff hunk is identical in shape (`-      tier: <word>`). A spot-check of any 2–3 files confirms the regex only touched the intended line.

Rollback: revert the merge commit. No data effects.

## Checklist

- [x] No production-data effects
- [x] No consumer-visible changes
- [x] Convention now in sync with code

## Companion PR

The user access audit work that surfaced this is in **#457**. Both PRs are independent and can land in either order; minor 3-way merge expected on the new `ds__user_access_audit.yml` if the audit PR merges first (the audit PR already creates that file without `tier`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)