### PR TITLE
fix(surveys): alias survey columns colliding with reserved base names

### DIFF
--- a/macros/surveys.sql
+++ b/macros/surveys.sql
@@ -16,15 +16,18 @@
 {% macro get_survey(survey_id) %}
     {%- set query = get_survey_columns(survey_id) -%}
     {%- set columns = dbt_utils.get_query_results_as_dict(query) -%}
-    SELECT 
+    {%- set reserved = ['encounter_id', 'response_id', 'patient_id',
+                        'start_datetime', 'end_datetime', 'result_text'] -%}
+    SELECT
         sr.encounter_id,
-        sra.response_id, 
+        sra.response_id,
         e.patient_id,
         sr.start_datetime,
         sr.end_datetime,
         sr.result_text
-    {%- for id, code in zip(columns['id'], columns['code']) %},
-            MAX(CASE WHEN sra.data_element_id = '{{ id }}' THEN NULLIF(sra.body,'') END) AS "{{ code }}"
+    {%- for id, code in zip(columns['id'], columns['code']) %}
+        {%- set alias = (code ~ '_answer') if code in reserved else code %},
+            MAX(CASE WHEN sra.data_element_id = '{{ id }}' THEN NULLIF(sra.body,'') END) AS "{{ alias }}"
     {% endfor %}
     FROM {{ ref('survey_responses') }} sr 
     JOIN {{ ref('survey_response_answers') }} sra 

--- a/scripts/tests/test_survey_utils.py
+++ b/scripts/tests/test_survey_utils.py
@@ -1,0 +1,25 @@
+import ast
+import re
+from pathlib import Path
+
+from utils.survey_utils import RESERVED_COLUMNS
+
+# repo root: scripts/tests -> scripts -> root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SURVEYS_MACRO = REPO_ROOT / "macros" / "surveys.sql"
+
+
+def _reserved_from_macro():
+    """Extract the `reserved` list literal from the get_survey macro."""
+    text = SURVEYS_MACRO.read_text(encoding="utf-8")
+    match = re.search(r"set\s+reserved\s*=\s*(\[.*?\])", text, re.DOTALL)
+    assert match, "could not find `set reserved = [...]` in macros/surveys.sql"
+    return set(ast.literal_eval(match.group(1)))
+
+
+def test_reserved_columns_in_sync_with_macro():
+    # The Python RESERVED_COLUMNS and the Jinja `reserved` list are
+    # hand-maintained in two files and must stay identical, otherwise survey
+    # data elements collide with base columns inconsistently across the
+    # generated SQL and YAML. Guards the drift the cross-reference comment warns about.
+    assert RESERVED_COLUMNS == _reserved_from_macro()

--- a/scripts/utils/survey_utils.py
+++ b/scripts/utils/survey_utils.py
@@ -111,6 +111,8 @@ models:
         description: '{{{{ doc("encounters__patient_id") }}}}'
       - name: start_datetime
         description: '{{{{ doc("survey_responses__start_time") }}}}'
+      - name: end_datetime
+        description: '{{{{ doc("survey_responses__end_time") }}}}'
       - name: result_text
         description: '{{{{ doc("survey_responses__result_text") }}}}'"""
 

--- a/scripts/utils/survey_utils.py
+++ b/scripts/utils/survey_utils.py
@@ -6,6 +6,19 @@ from .system_utils import cprint, execute_command_with_output
 BASE_DIR = Path.cwd()
 SURVEYS_DIR = BASE_DIR / "models" / "surveys"
 
+# Base columns emitted by the get_survey macro. A survey data element whose
+# normalised code matches one of these is aliased to "<code>_answer" in the
+# model SQL to avoid a duplicate-column collision; keep this in sync with the
+# `reserved` list in macros/surveys.sql.
+RESERVED_COLUMNS = {
+    "encounter_id",
+    "response_id",
+    "patient_id",
+    "start_datetime",
+    "end_datetime",
+    "result_text",
+}
+
 
 def get_surveys_from_deployment():
     """
@@ -107,8 +120,10 @@ models:
         doc_id = id.replace("-", "_")
         prefixed_doc_id = f"{survey_id}__{doc_id}"
         
+        column_name = f"{code}_answer" if code in RESERVED_COLUMNS else code
+
         doc_parts.append(f"""{{% docs {prefixed_doc_id} %}}\n{name.replace('"', "'")}\n{{% enddocs %}}""")
-        yml_parts.append(f"""\n      - name: {code}\n        description: '{{{{ doc("{prefixed_doc_id}") }}}}'""")  
+        yml_parts.append(f"""\n      - name: {column_name}\n        description: '{{{{ doc("{prefixed_doc_id}") }}}}'""")
 
     # Assuming 'doc' was initialized as an empty string  
     doc = "\n\n".join(doc_parts)  


### PR DESCRIPTION
The get_survey macro emits six fixed base columns (encounter_id, response_id, patient_id, start_datetime, end_datetime, result_text) and then pivots every survey data element into a column named after its code. A survey containing a data element whose normalised code matches a base column (e.g. `pde-patient-id` -> `patient_id`) produced a duplicate column, failing the model build with
`column "patient_id" specified more than once`.

Alias any pivoted column whose code collides with a reserved base name to `<code>_answer`, in both the model SQL (macros/surveys.sql) and the generated .yml docs (scripts/utils/survey_utils.py) so the documented column name matches the emitted one. Non-colliding columns are unchanged.

Verified against a Pakistan TB survey deployment: 26 previously-failing models now build on both dbt Core 1.11 and dbt-fusion 2.0.