### PR TITLE
chore: require maui code owner review for .github + Python (synced from maui-team)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for this repository.
+# See https://docs.github.com/articles/about-code-owners
+#
+# Changes to files under .github/ (CI workflows, deployment config,
+# this CODEOWNERS file) require review from the team below.
+
+/.github/ @beyondessential/maui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,17 @@
-# Code owners for this repository.
-# See https://docs.github.com/articles/about-code-owners
+# Canonical CODEOWNERS for Maui team repositories.
 #
-# Changes to files under .github/ (CI workflows, deployment config,
-# this CODEOWNERS file) require review from the team below.
+# This is the source of truth. Consuming repos do NOT edit their own
+# .github/CODEOWNERS by hand — the `sync-codeowners` reusable workflow copies
+# this file into <repo>/.github/CODEOWNERS and opens a PR when it drifts.
+#
+# GitHub only reads CODEOWNERS from a repo's root, .github/, or docs/ on the
+# default branch, so the file must physically exist in each repo; it cannot be
+# read from the .maui submodule directly.
+#
+# See https://docs.github.com/articles/about-code-owners
 
+# CI workflows, deployment config, and the CODEOWNERS file itself.
 /.github/ @beyondessential/maui
 
-# Any Python file requires review from the team below.
+# Any Python file, anywhere in the repo.
 *.py @beyondessential/maui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 # this CODEOWNERS file) require review from the team below.
 
 /.github/ @beyondessential/maui
+
+# Any Python file requires review from the team below.
+*.py @beyondessential/maui

--- a/.github/workflows/sync-codeowners.yml
+++ b/.github/workflows/sync-codeowners.yml
@@ -1,0 +1,16 @@
+name: Sync CODEOWNERS
+
+# Keeps .github/CODEOWNERS in sync with the canonical templates/CODEOWNERS in
+# the maui-team repo. See beyondessential/maui-team .github/workflows/README.md.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: beyondessential/maui-team/.github/workflows/sync-codeowners.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary
Requires `@beyondessential/maui` review for changes under `.github/` and to any Python file, with the rules sourced centrally from `maui-team`.

- **`.github/CODEOWNERS`** — code owner rules, byte-identical to the canonical `templates/CODEOWNERS` in maui-team.
- **`.github/workflows/sync-codeowners.yml`** — caller for the `sync-codeowners` reusable workflow; keeps this file in sync (weekly + manual dispatch).

## Enforcement
Branch protection on `main` is already set (`require_code_owner_reviews=true`, `required_approving_review_count=1`). The rule goes live once CODEOWNERS lands on `main`.

## Merge order
Depends on **beyondessential/maui-team#29** (adds the template + reusable workflow). Merge that first, otherwise the caller workflow's `uses: ...@main` reference won't resolve. The CODEOWNERS file itself works independently of #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)