### PR TITLE
chore: consume Maui skills via plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,18 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "maui-team": {
+      "source": {
+        "source": "directory",
+        "path": "./.maui"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "maui-tamanu@maui-team": true,
+    "maui-internal@maui-team": true,
+    "maui-core@maui-team": true
   }
 }


### PR DESCRIPTION
## Summary

Migrates this repo to consume Maui skills via the new **plugin marketplace**. The `maui-team` skills moved out of `.maui/skills/` (previously consumed through a `.claude/skills` → `.maui/skills` symlink) into plugins under `.maui/plugins/<plugin>/skills/` (maui-team PR #32). The old symlink now dangles, so consumers must switch.

- **Bump `.maui` submodule** to the merged marketplace layout (`28cd619`).
- **Merge into the existing `.claude/settings.json`** (the `SessionStart` hook is preserved): add `extraKnownMarketplaces` registering `.maui` as a local marketplace and `enabledPlugins` for **maui-tamanu, maui-internal, maui-core**.
- `.gitignore` already commits `.claude/settings.json` — unchanged.

## How it works

On trusting the repo, Claude Code prompts to install the `maui-team` marketplace and enable the plugins. Skills auto-discover and model-invoke as before; explicit invocation is namespaced, e.g. `/maui-tamanu:build-tamanu-reports`.

## Test plan

- [x] `.claude/settings.json` valid JSON; existing hook config preserved.
- [x] `.maui` resolves to the marketplace layout (`plugins/` + `.claude-plugin/marketplace.json`, name `maui-team`).
- [ ] Reviewer: open in Claude Code, accept prompts, confirm an enabled skill is available. (Verified end-to-end on the tamanu-dbt-template pilot.)

## Risk / rollback

Low risk: submodule pin + editor config merge only; no dbt/runtime code or hook behaviour touched. Rollback = revert the commit.
