### PR TITLE
ci: pass secrets: inherit to maui-team reusable workflows

### DIFF
--- a/.github/workflows/sync-codeowners.yml
+++ b/.github/workflows/sync-codeowners.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   sync:
     uses: beyondessential/maui-team/.github/workflows/sync-codeowners.yml@main
+    secrets: inherit
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

`maui-team` is going private. Its reusable workflows now mint a short-lived **GitHub App token** to fetch the private `.maui` submodule (maui-team #33), which needs the org secrets `MAUI_APP_ID` / `MAUI_APP_KEY`. A reusable workflow only receives the caller's secrets when the caller passes **`secrets: inherit`**.

Adds `secrets: inherit` to the caller job(s) for: sync-codeowners. (`claude-code-review` already inherits.)

Verified end-to-end on tamanu-dbt-template (App-token submodule fetch + bot push ran green while maui-team is public).

## Test plan
- [x] Workflow YAML still parses.
- [ ] No-op until maui-team #33 merges; after that, the reusable workflow reads the App secrets and fetches the private submodule.

## Risk / rollback
Trivial one-line change per caller job. Harmless before #33 merges. Rollback = revert.
