### PR TITLE
Add clinical__visit_occurrence canonical model and visit-type mapping

### DIFF
--- a/data_tests/data_test__clinical__visit_occurrence.sql
+++ b/data_tests/data_test__clinical__visit_occurrence.sql
@@ -1,0 +1,18 @@
+-- Singular tests for clinical__visit_occurrence. One row per violation, tagged with the
+-- acceptance criterion it breaks. See specs/dbt-model/clinical__visit_occurrence.md.
+
+with visit as (
+    select * from {{ ref('clinical__visit_occurrence') }}
+),
+
+-- AC-007: when visit_end_datetime is present it must not precede visit_start_datetime (BL-004)
+ac_007 as (
+    select
+        visit_occurrence_id,
+        'AC-007' as failed_ac
+    from visit
+    where visit_end_datetime is not null
+        and visit_end_datetime < visit_start_datetime
+)
+
+select visit_occurrence_id, failed_ac from ac_007

--- a/models/clinical/clinical__visit_occurrence.md
+++ b/models/clinical/clinical__visit_occurrence.md
@@ -1,0 +1,38 @@
+{% docs clinical__visit_occurrence %}
+OMOP-lite VISIT_OCCURRENCE domain: one row per encounter with OMOP visit-type
+concept ID alongside the Tamanu encounter_type source value. Canonical encounter
+surface for the clinical layer; visit_occurrence_id is the foreign key carried by
+downstream clinical event models.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_concept_id %}
+OMOP standard Visit concept ID for the encounter type (9201 Inpatient Visit,
+9202 Outpatient Visit, 9203 Emergency Room Visit). NULL when the encounter type
+has no corresponding standard concept.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_start_date %}
+Date component of the encounter start datetime.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_start_datetime %}
+Timestamp at which the encounter began.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_end_date %}
+Date component of the encounter end datetime. NULL for open or in-progress encounters.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_end_datetime %}
+Timestamp at which the encounter ended. NULL for open or in-progress encounters.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__visit_type_concept_id %}
+OMOP concept indicating how the visit was recorded. Always 32817 (EHR administration
+record) for Tamanu-sourced encounters.
+{% enddocs %}
+
+{% docs clinical__visit_occurrence__care_site_id %}
+UUID of the department the encounter is assigned to. Forward-compatible FK to a
+future ref__care_site model.
+{% enddocs %}

--- a/models/clinical/clinical__visit_occurrence.sql
+++ b/models/clinical/clinical__visit_occurrence.sql
@@ -14,6 +14,15 @@ with encounters as (
 
 visit_map as (
     select * from {{ ref('map__omop_visit_type') }}
+),
+
+-- collect the distinct encounter types seen in history for each encounter;
+-- used to detect admission encounters that passed through an ER phase (BL-002)
+encounter_history_types as (
+    select distinct
+        encounter_id,
+        encounter_type
+    from {{ ref('encounter_history') }}
 )
 
 select
@@ -24,7 +33,18 @@ select
     e.patient_id as person_id,
 
     -- visit type: concept shadow + retained source value (BL-002)
-    vm.concept_id as visit_concept_id,
+    -- admission encounters that had a prior emergency/triage/observation phase
+    -- map to 262 (Emergency Room and Inpatient Visit); all others use the map
+    case
+        when e.encounter_type = 'admission'
+            and exists (
+                select 1 from encounter_history_types eht
+                where eht.encounter_id = e.id
+                    and eht.encounter_type in ('emergency', 'triage', 'observation')
+            )
+        then 262
+        else vm.concept_id
+    end as visit_concept_id,
 
     -- visit datetimes (BL-004)
     e.start_datetime::date as visit_start_date,

--- a/models/clinical/clinical__visit_occurrence.sql
+++ b/models/clinical/clinical__visit_occurrence.sql
@@ -1,0 +1,46 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__visit_occurrence -- OMOP-lite VISIT_OCCURRENCE domain. One row per encounter (BL-001).
+-- Visit-concept shadow column sits alongside local encounter_type source value; native UUID PK
+-- (D1 OMOP-lite). Sources only from bases/ (D10).
+-- See specs/dbt-model/clinical__visit_occurrence.md for BL-001..BL-007.
+
+with encounters as (
+    select * from {{ ref('encounters') }}
+),
+
+visit_map as (
+    select * from {{ ref('map__omop_visit_type') }}
+)
+
+select
+    -- identity (BL-001)
+    e.id as visit_occurrence_id,
+
+    -- patient FK (BL-001)
+    e.patient_id as person_id,
+
+    -- visit type: concept shadow + retained source value (BL-002)
+    vm.concept_id as visit_concept_id,
+
+    -- visit datetimes (BL-004)
+    e.start_datetime::date as visit_start_date,
+    e.start_datetime       as visit_start_datetime,
+    e.end_datetime::date   as visit_end_date,
+    e.end_datetime         as visit_end_datetime,
+
+    -- visit type provenance: constant EHR administration record (BL-003)
+    32817 as visit_type_concept_id,
+
+    -- provider and care site (BL-005, BL-006)
+    e.clinician_id  as provider_id,
+    e.department_id as care_site_id,
+
+    -- source value retained alongside concept (BL-007)
+    e.encounter_type as visit_source_value
+
+from encounters e
+left join visit_map vm on vm.local_code = e.encounter_type

--- a/models/clinical/clinical__visit_occurrence.yml
+++ b/models/clinical/clinical__visit_occurrence.yml
@@ -1,0 +1,72 @@
+version: 2
+
+models:
+  - name: clinical__visit_occurrence
+    description: "{{ doc('clinical__visit_occurrence') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: visit_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('generic__id') }} of the encounter; the OMOP visit_occurrence_id."
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__visit_occurrence_visit_occurrence_id_not_null
+          - unique:
+              name: ac_002_clinical__visit_occurrence_visit_occurrence_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__patient_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_003_clinical__visit_occurrence_person_id_not_null
+          - relationships:
+              name: ac_003_clinical__visit_occurrence_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: visit_concept_id
+        data_type: integer
+        description: "{{ doc('clinical__visit_occurrence__visit_concept_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_004_clinical__visit_occurrence_visit_concept_id_mapped
+              arguments:
+                to: ref('map__omop_visit_type')
+                field: concept_id
+      - name: visit_start_date
+        data_type: date
+        description: "{{ doc('clinical__visit_occurrence__visit_start_date') }}"
+      - name: visit_start_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__visit_occurrence__visit_start_datetime') }}"
+        data_tests:
+          - not_null:
+              name: ac_006_clinical__visit_occurrence_visit_start_datetime_not_null
+      - name: visit_end_date
+        data_type: date
+        description: "{{ doc('clinical__visit_occurrence__visit_end_date') }}"
+      - name: visit_end_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__visit_occurrence__visit_end_datetime') }}"
+      - name: visit_type_concept_id
+        data_type: integer
+        description: "{{ doc('clinical__visit_occurrence__visit_type_concept_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_005_clinical__visit_occurrence_visit_type_concept_id_not_null
+      - name: provider_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__examiner_id') }}"
+      - name: care_site_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__visit_occurrence__care_site_id') }}"
+      - name: visit_source_value
+        data_type: character varying(255)
+        description: "{{ doc('encounters__encounter_type') }}"

--- a/models/maps/map__omop_visit_type.sql
+++ b/models/maps/map__omop_visit_type.sql
@@ -15,7 +15,7 @@ from (
         ('clinic',          'Outpatient Clinic',    9202, 'Outpatient Visit',          'Visit'),
         ('imaging',         'Imaging',              9202, 'Outpatient Visit',          'Visit'),
         ('emergency',       'Emergency',            9203, 'Emergency Room Visit',      'Visit'),
-        ('observation',     'Observation',          9202, 'Outpatient Visit',          'Visit'),
+        ('observation',     'Observation',          9203, 'Emergency Room Visit',      'Visit'),
         ('triage',          'Triage',               9203, 'Emergency Room Visit',      'Visit'),
         ('surveyResponse',  'Survey Response',         0, 'No matching concept',       'Visit'),
         ('vaccination',     'Vaccination',          9202, 'Outpatient Visit',          'Visit')

--- a/models/maps/map__omop_visit_type.sql
+++ b/models/maps/map__omop_visit_type.sql
@@ -12,6 +12,10 @@ select
 from (
     values
         ('admission',       'Inpatient Admission',  9201, 'Inpatient Visit',          'Visit'),
+        -- concept 262 is not a direct encounter_type lookup; it is applied by
+        -- clinical__visit_occurrence when an admission encounter had a prior
+        -- emergency/triage/observation phase in encounter_history (BL-002)
+        ('admission_from_emergency', 'Emergency Room and Inpatient Admission', 262, 'Emergency Room and Inpatient Visit', 'Visit'),
         ('clinic',          'Outpatient Clinic',    9202, 'Outpatient Visit',          'Visit'),
         ('imaging',         'Imaging',              9202, 'Outpatient Visit',          'Visit'),
         ('emergency',       'Emergency',            9203, 'Emergency Room Visit',      'Visit'),

--- a/models/maps/map__omop_visit_type.sql
+++ b/models/maps/map__omop_visit_type.sql
@@ -1,0 +1,22 @@
+-- Tamanu encounter_type codes -> OMOP Visit concept IDs (OHDSI Athena, vocabulary 'Visit').
+-- Universal mapping: applies to every deployment, so it lives in tamanu-source-dbt
+-- (derived-elements-conventions.md § map__omop seeds).
+-- View-over-values rather than a seed so it ships in the compiled production bundle.
+
+select
+    local_code,
+    local_name,
+    concept_id,
+    concept_name,
+    vocabulary_id
+from (
+    values
+        ('admission',       'Inpatient Admission',  9201, 'Inpatient Visit',          'Visit'),
+        ('clinic',          'Outpatient Clinic',    9202, 'Outpatient Visit',          'Visit'),
+        ('imaging',         'Imaging',              9202, 'Outpatient Visit',          'Visit'),
+        ('emergency',       'Emergency',            9203, 'Emergency Room Visit',      'Visit'),
+        ('observation',     'Observation',          9202, 'Outpatient Visit',          'Visit'),
+        ('triage',          'Triage',               9203, 'Emergency Room Visit',      'Visit'),
+        ('surveyResponse',  'Survey Response',         0, 'No matching concept',       'Visit'),
+        ('vaccination',     'Vaccination',          9202, 'Outpatient Visit',          'Visit')
+) as t (local_code, local_name, concept_id, concept_name, vocabulary_id)

--- a/models/maps/map__omop_visit_type.yml
+++ b/models/maps/map__omop_visit_type.yml
@@ -1,0 +1,45 @@
+version: 2
+
+models:
+  - name: map__omop_visit_type
+    description: >-
+      Tamanu encounter_type codes mapped to OMOP standardised Visit concept IDs
+      (vocabulary 'Visit'). Universal across deployments. Joined by
+      clinical__visit_occurrence to populate visit_concept_id shadow columns.
+    config:
+      tags:
+        - reference
+    meta:
+      owner: bes-maui
+      domain: reference
+    columns:
+      - name: local_code
+        data_type: text
+        description: Tamanu encounter_type value (e.g. admission, clinic, emergency).
+        data_tests:
+          - not_null
+          - unique
+      - name: local_name
+        data_type: text
+        description: Human-readable Tamanu encounter type label.
+        data_tests:
+          - not_null
+      - name: concept_id
+        data_type: integer
+        description: >-
+          OMOP standard concept ID for the visit type (9201 = Inpatient Visit,
+          9202 = Outpatient Visit, 9203 = Emergency Room Visit, 0 = no matching concept).
+        data_tests:
+          - not_null
+      - name: concept_name
+        data_type: text
+        description: OMOP concept name for the visit concept.
+        data_tests:
+          - not_null
+      - name: vocabulary_id
+        data_type: text
+        description: OMOP vocabulary the concept belongs to.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["Visit"]

--- a/specs/dbt-model/clinical__visit_occurrence.md
+++ b/specs/dbt-model/clinical__visit_occurrence.md
@@ -69,11 +69,19 @@ All joins in this model are many-to-one (encounter → map row), so grain is pre
 - **BL-001:** One row per encounter, sourced from `{{ ref('encounters') }}` only — never
   `public.*` (D10). Deleted / test-patient filtering is inherited from the base model.
 - **BL-002:** `visit_concept_id` is the OMOP standard Visit concept for the encounter
-  type, looked up from `map__omop_visit_type` on
-  `lower(encounter_type) = local_code`. The local value is preserved verbatim as
+  type. For all types except `admission` it is looked up from `map__omop_visit_type`
+  on `encounter_type = local_code`. The local value is preserved verbatim as
   `visit_source_value`. An unmapped type yields a NULL concept — the row is kept,
   never dropped. `observation` maps to 9203 (Emergency Room Visit) because it is
   part of the Tamanu emergency workflow, not a standalone outpatient encounter.
+  For `admission` encounters, the concept depends on encounter history: if
+  `encounter_history` contains a prior `emergency`, `triage`, or `observation`
+  phase for the same encounter, `visit_concept_id` is 262 (Emergency Room and
+  Inpatient Visit); otherwise it is 9201 (Inpatient Visit). This reflects the OMOP
+  CDM convention that a single ER-to-inpatient episode is one visit with concept 262,
+  not two separate visit occurrences. The 262 concept is registered in
+  `map__omop_visit_type` under `local_code = 'admission_from_emergency'` so the
+  referential-integrity test on `visit_concept_id` (AC-004) covers it.
 - **BL-003:** `visit_type_concept_id` is the constant 32817 ("EHR administration
   record") for every row. All Tamanu encounters originate from EHR entry; no
   deployment-specific override is needed (unlike ethnicity or billing mappings).
@@ -117,6 +125,7 @@ row (D5, dbt-conventions § Documentation).
 | Ref | Layer | Role |
 |---|---|---|
 | `encounters` | `bases/` | Encounter identity, type, datetimes, clinician, department |
+| `encounter_history` | `bases/` | Prior encounter types per encounter; used to detect ER→admission transitions (BL-002) |
 | `map__omop_visit_type` | `maps/` | Tamanu encounter_type → OMOP Visit concept (universal) |
 | `clinical__person` | `clinical/` | Parent PERSON domain; `person_id` FK target |
 

--- a/specs/dbt-model/clinical__visit_occurrence.md
+++ b/specs/dbt-model/clinical__visit_occurrence.md
@@ -72,7 +72,8 @@ All joins in this model are many-to-one (encounter → map row), so grain is pre
   type, looked up from `map__omop_visit_type` on
   `lower(encounter_type) = local_code`. The local value is preserved verbatim as
   `visit_source_value`. An unmapped type yields a NULL concept — the row is kept,
-  never dropped.
+  never dropped. `observation` maps to 9203 (Emergency Room Visit) because it is
+  part of the Tamanu emergency workflow, not a standalone outpatient encounter.
 - **BL-003:** `visit_type_concept_id` is the constant 32817 ("EHR administration
   record") for every row. All Tamanu encounters originate from EHR entry; no
   deployment-specific override is needed (unlike ethnicity or billing mappings).

--- a/specs/dbt-model/clinical__visit_occurrence.md
+++ b/specs/dbt-model/clinical__visit_occurrence.md
@@ -125,10 +125,17 @@ row (D5, dbt-conventions § Documentation).
   `ref__care_site` canonical lookup. A future `ref__care_site` model (wrapping
   `bases/departments` and `bases/facilities`) should be added so the FK can be
   validated. Until then, AC on this column is deferred.
-- **OQ-2:** Mid-encounter department and location changes (tracked in
-  `encounter_history`) are not surfaced here. OMOP handles this via
-  `VISIT_DETAIL` rows — a future `clinical__visit_detail` model could expose
-  the full ward-transfer history from `int__admission_history_*`.
+- **OQ-2:** Mid-encounter transitions — department/location transfers *and*
+  encounter-type changes (e.g. `triage` → `emergency` → `admission`) — are
+  tracked in `encounter_history` but not surfaced here. In Tamanu, an ER-to-
+  admission flow is a **single encounter** whose type changes over time; there
+  is no second encounter record, so `preceding_visit_occurrence_id` does not
+  apply. `VISIT_OCCURRENCE` correctly reflects the final/current type. OMOP
+  handles the intra-visit phases via `VISIT_DETAIL` rows — a future
+  `clinical__visit_detail` model should expose one row per `encounter_history`
+  segment (carrying `encounter_type`, department, location, and datetime range
+  per segment) built from `int__admission_history_*` and the `encounter_type`
+  column in `bases/encounter_history`.
 - **OQ-3:** `surveyResponse` encounters are included with `visit_concept_id = NULL`
   (no OMOP equivalent). If downstream models should exclude survey encounters,
   they can filter on `visit_source_value != 'surveyResponse'` or on non-null

--- a/specs/dbt-model/clinical__visit_occurrence.md
+++ b/specs/dbt-model/clinical__visit_occurrence.md
@@ -1,0 +1,135 @@
+# dbt Model Spec: `clinical__visit_occurrence` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__visit_occurrence` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `implemented` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-06-28 |
+| **Last updated** | 2026-06-28 |
+
+The OMOP-lite `VISIT_OCCURRENCE` domain — the canonical encounter surface every
+`clinical__`, `derived__`, `metric__`, and `dataset__` model joins to for visit
+context. Second model of the canonical clinical layer; the event hub of the
+OMOP foreign-key graph (`visit_occurrence_id` is carried by condition, procedure,
+measurement, and observation event tables). See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One row per encounter, in OMOP `VISIT_OCCURRENCE`
+shape: native UUID primary key, standardised visit-type concept ID alongside the
+Tamanu encounter-type source value, visit start/end datetimes, attending provider
+reference, and department care-site reference.
+
+**Clinical context.** Tamanu records all patient–facility interactions as
+`encounters`, typed by `encounter_type` (admission, clinic, emergency, etc.). OMOP
+analytics expect a single canonical `VISIT_OCCURRENCE` row per encounter keyed by
+`visit_occurrence_id`. This model is that contract.
+
+**Who reads it.** Every downstream canonical model that needs a visit anchor:
+`clinical__condition_occurrence` and future event tables (via `visit_occurrence_id`),
+`derived__cohort_*` (visit counts, admission windows), `metric__` calculations
+(admission rates, length-of-stay distributions), and `dataset__` encounter summaries.
+
+## Grain
+
+**One row per:** encounter.
+
+Source `encounters` (via `bases/`) already filters soft-deleted encounters and the
+test patient. No fan-out risk: `encounters.id` is the PK of the source table.
+All joins in this model are many-to-one (encounter → map row), so grain is preserved.
+
+## Output schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `visit_occurrence_id` | uuid | `encounters.id`. Native UUID PK — no remap to OMOP integer IDs (D1) |
+| `person_id` | uuid | `encounters.patient_id`. FK to `clinical__person.person_id` |
+| `visit_concept_id` | integer | OMOP Visit concept from `map__omop_visit_type` (9201 Inpatient, 9202 Outpatient, 9203 ER, 0 no-match). NULL if unmapped |
+| `visit_start_date` | date | Date component of `start_datetime` |
+| `visit_start_datetime` | timestamp | `encounters.start_datetime`. Always non-null |
+| `visit_end_date` | date | Date component of `end_datetime`. NULL for open encounters |
+| `visit_end_datetime` | timestamp | `encounters.end_datetime`. NULL for open encounters |
+| `visit_type_concept_id` | integer | Constant 32817 (EHR administration record) — all encounters originate from the Tamanu EHR |
+| `provider_id` | uuid | `encounters.clinician_id`. The attending clinician at encounter creation. NULL when no clinician recorded |
+| `care_site_id` | uuid | `encounters.department_id`. The department the encounter is assigned to. NULL when no department recorded |
+| `visit_source_value` | text | `encounters.encounter_type`. Tamanu local code, retained alongside the concept ID (D1) |
+
+## Business logic
+
+- **BL-001:** One row per encounter, sourced from `{{ ref('encounters') }}` only — never
+  `public.*` (D10). Deleted / test-patient filtering is inherited from the base model.
+- **BL-002:** `visit_concept_id` is the OMOP standard Visit concept for the encounter
+  type, looked up from `map__omop_visit_type` on
+  `lower(encounter_type) = local_code`. The local value is preserved verbatim as
+  `visit_source_value`. An unmapped type yields a NULL concept — the row is kept,
+  never dropped.
+- **BL-003:** `visit_type_concept_id` is the constant 32817 ("EHR administration
+  record") for every row. All Tamanu encounters originate from EHR entry; no
+  deployment-specific override is needed (unlike ethnicity or billing mappings).
+- **BL-004:** `visit_start_date` and `visit_start_datetime` are always non-null
+  (inherited from `bases/encounters`, which sources from a `not_null`-tested source
+  column). `visit_end_date` and `visit_end_datetime` are NULL for open / in-progress
+  encounters — no sentinel value is substituted, so a NULL end date means "not yet
+  discharged" unambiguously.
+- **BL-005:** `provider_id` is `clinician_id` from `bases/encounters` (the Tamanu
+  `examiner_id`, renamed at base layer). This is the clinician recorded at encounter
+  creation; mid-encounter clinician changes tracked in `encounter_history` are not
+  reflected here (they belong to a future `clinical__provider_visit` event if needed).
+- **BL-006:** `care_site_id` is `department_id` from `bases/encounters`. It represents
+  the department the encounter is assigned to at creation. No `ref__care_site` model
+  exists yet; `care_site_id` is carried as a raw UUID FK so future joins are
+  forward-compatible when `ref__care_site` is built.
+- **BL-007:** `visit_source_value` carries the raw Tamanu `encounter_type` value
+  alongside the OMOP concept. It is not a direct identifier and is not withheld on
+  analytics targets.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `visit_occurrence_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `visit_occurrence_id` is `unique` | grain | dbt `unique` |
+| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-001 | dbt `relationships` |
+| AC-004 | Every non-null `visit_concept_id` exists in `map__omop_visit_type.concept_id` | BL-002 | dbt `relationships` |
+| AC-005 | `visit_type_concept_id` is `not_null` and always 32817 | BL-003 | dbt `not_null` |
+| AC-006 | `visit_start_datetime` is `not_null` | BL-004 | dbt `not_null` |
+| AC-007 | When `visit_end_datetime` is non-null, `visit_end_datetime >= visit_start_datetime` | BL-004 | dbt singular test |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` and `derived__` artefacts get a `metric_definitions.csv`
+row (D5, dbt-conventions § Documentation).
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `encounters` | `bases/` | Encounter identity, type, datetimes, clinician, department |
+| `map__omop_visit_type` | `maps/` | Tamanu encounter_type → OMOP Visit concept (universal) |
+| `clinical__person` | `clinical/` | Parent PERSON domain; `person_id` FK target |
+
+## Open questions
+
+- **OQ-1:** `care_site_id` references `department_id` without a corresponding
+  `ref__care_site` canonical lookup. A future `ref__care_site` model (wrapping
+  `bases/departments` and `bases/facilities`) should be added so the FK can be
+  validated. Until then, AC on this column is deferred.
+- **OQ-2:** Mid-encounter department and location changes (tracked in
+  `encounter_history`) are not surfaced here. OMOP handles this via
+  `VISIT_DETAIL` rows — a future `clinical__visit_detail` model could expose
+  the full ward-transfer history from `int__admission_history_*`.
+- **OQ-3:** `surveyResponse` encounters are included with `visit_concept_id = NULL`
+  (no OMOP equivalent). If downstream models should exclude survey encounters,
+  they can filter on `visit_source_value != 'surveyResponse'` or on non-null
+  `visit_concept_id`.


### PR DESCRIPTION
## Summary

Implements the OMOP-lite `VISIT_OCCURRENCE` canonical domain model as the central encounter surface for the clinical layer. This is the second canonical clinical model and serves as the event hub for the OMOP foreign-key graph, carrying `visit_occurrence_id` to downstream event tables (conditions, procedures, measurements, observations).

## Key Changes

- **`clinical__visit_occurrence` model** — One row per encounter with:
  - Native UUID primary key (`visit_occurrence_id` from `encounters.id`)
  - OMOP standardised visit-type concept ID alongside Tamanu `encounter_type` source value
  - Visit start/end datetimes (end nullable for open encounters)
  - Provider and care-site references
  - Special handling for ER-to-admission transitions: when an `admission` encounter has prior `emergency`, `triage`, or `observation` phases in `encounter_history`, `visit_concept_id` is set to 262 (Emergency Room and Inpatient Visit) rather than 9201, reflecting OMOP CDM convention that a single ER-to-inpatient episode is one visit, not two

- **`map__omop_visit_type` reference model** — Universal Tamanu encounter_type → OMOP Visit concept mapping:
  - Covers all Tamanu encounter types (admission, clinic, imaging, emergency, observation, triage, surveyResponse, vaccination)
  - Includes synthetic `admission_from_emergency` entry (concept 262) for referential-integrity testing
  - Implemented as a view-over-values (not a seed) for inclusion in compiled production bundle

- **Comprehensive specification document** (`specs/dbt-model/clinical__visit_occurrence.md`):
  - Detailed business logic (BL-001 through BL-007)
  - Seven acceptance criteria with corresponding dbt tests
  - Open questions on future `ref__care_site` model and `clinical__visit_detail` for intra-visit phases

- **dbt configuration**:
  - Environment-aware materialisation: `view` in production (`reporting_*`), `table` on replica (`analytics_*`)
  - Singular test for AC-007 (end datetime ≥ start datetime)
  - Relationships tests validating `person_id` and `visit_concept_id` foreign keys
  - Metadata tags and PII classification

## Notable Implementation Details

- **No OMOP integer ID remapping**: Retains native Tamanu UUIDs as primary keys (per D1 architecture decision)
- **Source-only from `bases/`**: Never joins `public.*` tables directly; inherits soft-delete and test-patient filtering from base models
- **Encounter-history-aware concept mapping**: Detects ER→admission transitions via subquery on `encounter_history` to apply concept 262
- **Nullable end datetimes**: Open encounters have NULL `visit_end_date` and `visit_end_datetime` (no sentinel values)
- **Forward-compatible FK design**: `care_site_id` carries raw UUID so future `ref__care_site` model can be added without schema changes

https://claude.ai/code/session_01QmqeKhvUHa4rEQzu1vnDXC