### PR TITLE
ci: inline Claude review workflow (public repo can't call private reusable workflow)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,11 @@
 name: Claude Code Review
 
+# Inlined rather than calling beyondessential/maui-team's reusable workflow: this repo is
+# public and maui-team is private, and GitHub does not let a public repo call a reusable
+# workflow in a private repo (the call fails at resolution with "workflow was not found").
+# The steps below mirror that reusable workflow. Keep in sync with
+# .maui/.github/workflows/claude-code-review.yml when it changes.
+
 on:
   pull_request:
     types: [opened]
@@ -15,5 +21,76 @@ jobs:
         contains(github.event.comment.body, '/review') &&
         github.event.comment.author_association != 'NONE' &&
         github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR')
-    uses: beyondessential/maui-team/.github/workflows/claude-code-review.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      # .maui is a private submodule (maui-team); mint a short-lived read token scoped to
+      # maui-team so the submodule can be fetched (REVIEW.md lives at .maui/REVIEW.md).
+      - name: Mint maui-team read token
+        id: maui-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MAUI_APP_ID }}
+          private-key: ${{ secrets.MAUI_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: maui-team
+
+      - name: Authenticate git for the private maui-team submodule
+        env:
+          MAUI_TOKEN: ${{ steps.maui-token.outputs.token }}
+        run: |
+          git config --global \
+            url."https://x-access-token:${MAUI_TOKEN}@github.com/beyondessential/maui-team".insteadOf \
+            "https://github.com/beyondessential/maui-team"
+
+      - name: Resolve PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          PR_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+
+      # submodules: false so checkout's GITHUB_TOKEN auth is not applied to the maui-team
+      # fetch; .maui is initialised explicitly below using the App-token URL rewrite above.
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          fetch-depth: 0
+          submodules: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Initialise .maui submodule
+        run: git submodule update --init .maui
+
+      - name: Resolve review reference file
+        id: review
+        run: |
+          if [ -f REVIEW.md ]; then
+            echo "path=REVIEW.md" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=.maui/REVIEW.md" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          use_sticky_comment: true
+          prompt: "/review"
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(gh pr *),Bash(gh api*),Bash(git diff*),Bash(git log*)"
+            --append-system-prompt "Read ${{ steps.review.outputs.path }} and follow all instructions in it."


### PR DESCRIPTION
## Summary

Replaces the cross-repo reusable-workflow call in `.github/workflows/claude-code-review.yml` with the equivalent steps inlined, so `/review` (and the on-open review) actually run.

## Root cause

`tamanu-source-dbt` is **public**; `maui-team` (which holds the shared reusable workflow) is **private**. GitHub does not allow a **public** repo to call a reusable workflow in a **private** repo — the call fails at *resolution* with:

> `error parsing called workflow … -> "beyondessential/maui-team/.github/workflows/claude-code-review.yml@main" : workflow was not found`

This is unaffected by the org "Access" setting (`access_level: organization`), which only grants private/internal callers. It broke when maui-team was made private (~2026-06-28); the last green run was ~30 min prior.

## What changed

- Inlined the steps that the maui-team reusable workflow ran: mint a maui-team App token → fetch the private `.maui` submodule (a `git clone` with a token, **not** subject to the reusable-workflow visibility rule) → resolve `REVIEW.md` (repo-local, else `.maui/REVIEW.md`) → run `anthropics/claude-code-action@v1` with `/review`.
- **Triggers unchanged and intentional:** PR `opened` + on-demand `/review` comment from a member/collaborator. **Not** on `synchronize` (no per-push reviews).
- Dropped the reusable workflow's auto-commit-`.maui`-submodule-update side behaviour (not needed for review; keeps `contents: read`).

## Notes / trade-offs

- The review workflow is no longer centrally shared from maui-team for this repo — keep it in sync with `.maui/.github/workflows/claude-code-review.yml` if that changes. A short comment at the top of the file says so.
- Requires the org secrets `MAUI_APP_ID` / `MAUI_APP_KEY` and repo/org secret `ANTHROPIC_API_KEY` (all already present). As with any public-repo workflow, secrets aren't exposed to PRs from forks — fork PRs won't get a secret-backed review (same limitation as before).
- The broader fix for the shared workflow (so *public* consumer repos can use it) is a maui-team-side decision — documented separately; this unblocks `/review` here now.

## Test plan

- YAML validated (parses; 7 steps).
- After merge to `main`, verify by commenting `/review` on an open PR — it should resolve and run (this PR itself only exercises it once merged, since `issue_comment` uses the default-branch workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)