### PR TITLE
feat(clinical): add clinical__condition_occurrence (encounter diagnoses)

### DIFF
--- a/models/clinical/clinical__condition_occurrence.md
+++ b/models/clinical/clinical__condition_occurrence.md
@@ -1,0 +1,55 @@
+{% docs clinical__condition_occurrence %}
+OMOP-lite CONDITION_OCCURRENCE domain: one row per encounter diagnosis, with the Tamanu
+ICD-10 diagnosis retained as the source value and the person/visit/provider foreign keys
+that anchor it in the OMOP graph. condition_concept_id (standard SNOMED) is deferred to the
+future vocab__ layer. Program-registry conditions are a planned second source.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_occurrence_id %}
+Unique identifier for the diagnosis; the OMOP condition_occurrence_id (the
+encounter_diagnoses id).
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__visit_occurrence_id %}
+The encounter the diagnosis was recorded on; the OMOP visit_occurrence_id. FK to
+clinical__visit_occurrence.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_start_date %}
+Date component of the diagnosis datetime.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_start_datetime %}
+Timestamp at which the diagnosis was recorded.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_end_date %}
+Date the condition resolved. NULL — Tamanu encounter diagnoses are point-in-time and carry
+no resolution date.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_end_datetime %}
+Timestamp the condition resolved. NULL — as above.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_type_source_value %}
+Provenance of the diagnosis. Constant 'encounter diagnosis' for this domain; a future
+program-registry source will carry a distinct value.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_status_source_value %}
+The diagnosis certainty as recorded in Tamanu (e.g. confirmed, suspected). Disproven and
+error certainties are excluded upstream.
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__is_primary %}
+Whether this was the primary diagnosis on the encounter (vs a secondary diagnosis).
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_source_value %}
+The diagnosis's ICD-10 code (Tamanu reference-data code).
+{% enddocs %}
+
+{% docs clinical__condition_occurrence__condition_source_name %}
+The diagnosis's readable name (Tamanu reference-data name), denormalised alongside the code.
+{% enddocs %}

--- a/models/clinical/clinical__condition_occurrence.sql
+++ b/models/clinical/clinical__condition_occurrence.sql
@@ -1,0 +1,54 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__condition_occurrence -- OMOP-lite CONDITION_OCCURRENCE domain. One row per
+-- encounter diagnosis (BL-001). FK graph anchored on the encounter (BL-002); the ICD-10
+-- code is retained as the source value and condition_concept_id is deferred to the future
+-- vocab__ layer (BL-003). Sources only from bases/ (D10).
+-- See specs/dbt-model/clinical__condition_occurrence.md for BL-001..BL-006.
+
+with encounter_diagnoses as (
+    select * from {{ ref('encounter_diagnoses') }}
+),
+
+encounters as (
+    select * from {{ ref('encounters') }}
+),
+
+reference_data as (
+    select * from {{ ref('reference_data') }}
+)
+
+select
+    -- identity (BL-001)
+    ed.id as condition_occurrence_id,
+
+    -- person anchored on the encounter (BL-002)
+    e.patient_id as person_id,
+
+    -- diagnosis datetimes; encounter diagnoses are point-in-time, so no end (BL-004)
+    ed.datetime::date as condition_start_date,
+    ed.datetime       as condition_start_datetime,
+    null::date        as condition_end_date,
+    null::timestamp   as condition_end_datetime,
+
+    -- provenance: every row here is an EHR encounter diagnosis (BL-006)
+    'encounter diagnosis' as condition_type_source_value,
+
+    -- status + primary/secondary flag; certainty retained verbatim (BL-005)
+    ed.certainty  as condition_status_source_value,
+    ed.is_primary as is_primary,
+
+    -- provider + visit FKs (BL-002)
+    ed.diagnosed_by_id as provider_id,
+    ed.encounter_id    as visit_occurrence_id,
+
+    -- diagnosis ICD-10 code + name; concept_id deferred to vocab__ (BL-003)
+    rd.code as condition_source_value,
+    rd.name as condition_source_name
+
+from encounter_diagnoses ed
+join encounters e on e.id = ed.encounter_id
+left join reference_data rd on rd.id = ed.diagnosis_id

--- a/models/clinical/clinical__condition_occurrence.yml
+++ b/models/clinical/clinical__condition_occurrence.yml
@@ -1,0 +1,79 @@
+version: 2
+
+models:
+  - name: clinical__condition_occurrence
+    description: "{{ doc('clinical__condition_occurrence') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: condition_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__condition_occurrence_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__condition_occurrence_condition_occurrence_id_not_null
+          - unique:
+              name: ac_002_clinical__condition_occurrence_condition_occurrence_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__patient_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_003_clinical__condition_occurrence_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: condition_start_date
+        data_type: date
+        description: "{{ doc('clinical__condition_occurrence__condition_start_date') }}"
+      - name: condition_start_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__condition_occurrence__condition_start_datetime') }}"
+        data_tests:
+          - not_null:
+              name: ac_006_clinical__condition_occurrence_condition_start_datetime_not_null
+      - name: condition_end_date
+        data_type: date
+        description: "{{ doc('clinical__condition_occurrence__condition_end_date') }}"
+      - name: condition_end_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__condition_occurrence__condition_end_datetime') }}"
+      - name: condition_type_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__condition_type_source_value') }}"
+      - name: condition_status_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__condition_status_source_value') }}"
+      - name: is_primary
+        data_type: boolean
+        description: "{{ doc('clinical__condition_occurrence__is_primary') }}"
+      - name: provider_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__examiner_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_005_clinical__condition_occurrence_provider_id_in_ref__provider
+              arguments:
+                to: ref('ref__provider')
+                field: provider_id
+      - name: visit_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__visit_occurrence_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_004_clinical__condition_occurrence_visit_occurrence_id_in_clinical__visit_occurrence
+              arguments:
+                to: ref('clinical__visit_occurrence')
+                field: visit_occurrence_id
+      - name: condition_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__condition_source_value') }}"
+      - name: condition_source_name
+        data_type: character varying(255)
+        description: "{{ doc('clinical__condition_occurrence__condition_source_name') }}"

--- a/specs/dbt-model/clinical__condition_occurrence.md
+++ b/specs/dbt-model/clinical__condition_occurrence.md
@@ -1,0 +1,138 @@
+# dbt Model Spec: `clinical__condition_occurrence` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__condition_occurrence` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `implemented` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-07-03 |
+| **Last updated** | 2026-07-03 |
+
+The OMOP-lite `CONDITION_OCCURRENCE` domain — one row per recorded diagnosis. First clinical
+**event** table hanging off the `visit_occurrence_id` hub. This iteration covers **encounter
+diagnoses**; program-registry conditions are the planned second source (OQ-1). See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping, `vocab__` future),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One row per encounter diagnosis, in OMOP
+`CONDITION_OCCURRENCE` shape: native UUID PK, the Tamanu diagnosis (ICD-10) retained as the
+source value, diagnosis datetime, certainty as the condition status, and the person /
+visit / provider foreign keys that anchor it in the OMOP graph.
+
+**Clinical context.** Tamanu records diagnoses as `encounter_diagnoses` rows against an
+encounter, each pointing at a `reference_data` diagnosis (ICD-10 code), with a `certainty`
+and an `is_primary` flag. OMOP analytics expect these as `CONDITION_OCCURRENCE` rows keyed
+by `condition_occurrence_id` and joined to `VISIT_OCCURRENCE`/`PERSON`.
+
+**Who reads it.** `derived__cohort_*` (disease cohorts — e.g. NCD patients identified by
+diagnosis), `metric__` NCD indicators (prevalence, controlled-rate denominators keyed on a
+diagnosis), and `dataset__` diagnosis line-lists.
+
+## Grain
+
+**One row per:** encounter diagnosis. `bases/encounter_diagnoses` already filters
+soft-deleted rows, the test patient, and `disproven`/`error` certainties, and its
+`encounter_diagnoses.id` is the PK of the source table. All joins here (→ `encounters` for
+person/visit, → `reference_data` for the diagnosis code) are many-to-one, so grain is
+preserved.
+
+## Output schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `condition_occurrence_id` | uuid | `encounter_diagnoses.id`. Native UUID PK — no remap to OMOP integer IDs (D1) |
+| `person_id` | uuid | `encounters.patient_id` (via `encounter_id`). FK to `clinical__person.person_id` |
+| `condition_start_date` | date | Date component of the diagnosis datetime |
+| `condition_start_datetime` | timestamp | `encounter_diagnoses.date`. Always non-null |
+| `condition_end_date` | date | NULL — encounter diagnoses are point-in-time (no resolution date recorded) |
+| `condition_end_datetime` | timestamp | NULL — as above |
+| `condition_type_source_value` | text | Constant `'encounter diagnosis'` — provenance. A future registry source (OQ-1) uses a distinct value |
+| `condition_status_source_value` | text | `encounter_diagnoses.certainty` (e.g. confirmed, suspected). Retained verbatim |
+| `is_primary` | boolean | `encounter_diagnoses.is_primary` — primary vs secondary diagnosis on the encounter |
+| `provider_id` | uuid | `encounter_diagnoses.diagnosed_by_id`. FK to `ref__provider.provider_id`. NULL when no clinician recorded |
+| `visit_occurrence_id` | uuid | `encounter_diagnoses.encounter_id`. FK to `clinical__visit_occurrence.visit_occurrence_id` |
+| `condition_source_value` | text | The diagnosis `reference_data.code` (ICD-10), via `diagnosis_id`. The Tamanu local code (D1) |
+| `condition_source_name` | text | The diagnosis `reference_data.name`, denormalised for readability |
+
+`condition_concept_id` / `condition_source_concept_id` (OMOP standard SNOMED) are **not**
+emitted — see BL-003. `condition_status_concept_id` and `condition_type_concept_id` are
+likewise deferred (BL-005, BL-006): only the source values are populated for now.
+
+## Business logic
+
+- **BL-001:** One row per encounter diagnosis, sourced from `{{ ref('encounter_diagnoses') }}`,
+  `{{ ref('encounters') }}` (person + visit anchor), and `{{ ref('reference_data') }}` (the
+  diagnosis code/name) only (D10) — never `public.*`. Soft-delete, test-patient, and
+  `disproven`/`error`-certainty filtering are inherited from `bases/encounter_diagnoses`.
+  `encounter_diagnoses.id` is the PK; the joins are many-to-one, so grain is preserved.
+- **BL-002:** OMOP foreign keys are wired from the encounter: `person_id` is the encounter's
+  `patient_id`, `visit_occurrence_id` is the `encounter_id`, and `provider_id` is
+  `diagnosed_by_id`. All are native UUIDs (D1) and resolve to `clinical__person`,
+  `clinical__visit_occurrence`, and `ref__provider` respectively.
+- **BL-003:** `condition_source_value` is the diagnosis's `reference_data.code` (ICD-10) and
+  `condition_source_name` its `reference_data.name`. `condition_concept_id` (OMOP standard
+  SNOMED) is **not** emitted: ICD-10 → SNOMED mapping requires the OMOP vocabulary tables
+  (the future `vocab__` layer, D2), not a small `map__omop_*` seed. The source code is
+  retained so the standard concept can be layered on when `vocab__` exists (OQ-2), never
+  replacing the local value (D1).
+- **BL-004:** `condition_start_date` / `condition_start_datetime` come from the diagnosis
+  `date` (always present). `condition_end_date` / `condition_end_datetime` are NULL —
+  Tamanu encounter diagnoses are point-in-time and carry no resolution date; no sentinel is
+  substituted.
+- **BL-005:** `condition_status_source_value` is the raw `certainty`; `is_primary` is
+  carried as the primary/secondary flag. `condition_status_concept_id` is deferred (no
+  status vocabulary in use). The base model already drops `disproven` and `error`
+  certainties, so only clinically-asserted diagnoses appear.
+- **BL-006:** `condition_type_source_value` is the constant `'encounter diagnosis'`,
+  recording provenance. `condition_type_concept_id` is deferred pending a verified
+  condition-type concept. The constant is also the discriminator for the future union with
+  program-registry conditions (OQ-1), which will carry a distinct type value.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `condition_occurrence_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `condition_occurrence_id` is `unique` | grain | dbt `unique` |
+| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-002 | dbt `relationships` |
+| AC-004 | Every `visit_occurrence_id` exists in `clinical__visit_occurrence.visit_occurrence_id` | BL-002 | dbt `relationships` |
+| AC-005 | Every non-null `provider_id` exists in `ref__provider.provider_id` | BL-002 | dbt `relationships` |
+| AC-006 | `condition_start_datetime` is `not_null` | BL-004 | dbt `not_null` |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` / `derived__` artefacts get a `metric_definitions.csv` row.
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `encounter_diagnoses` | `bases/` | Diagnosis identity, date, certainty, is_primary, diagnosis code FK, clinician |
+| `encounters` | `bases/` | Person (`patient_id`) and visit (`encounter_id`) anchor |
+| `reference_data` | `bases/` | Diagnosis ICD-10 code and name (via `diagnosis_id`) |
+| `clinical__person` | `clinical/` | `person_id` FK target (AC-003) |
+| `clinical__visit_occurrence` | `clinical/` | `visit_occurrence_id` FK target (AC-004) |
+| `ref__provider` | `ref/` | `provider_id` FK target (AC-005) |
+
+## Open questions
+
+- **OQ-1:** Program-registry conditions (`patient_program_registration_conditions`) are a
+  second diagnosis source and are **not** yet included. They differ in shape — no encounter
+  (so `visit_occurrence_id` NULL), person via `patient_program_registrations.patient_id`,
+  condition via `program_registry_conditions`, and status from
+  `program_registry_condition_category`. Add them as a `union all` second branch (with
+  `condition_type_source_value = 'program registry'`) when the registry-driven NCD cohort
+  needs them.
+- **OQ-2:** `condition_concept_id` (standard SNOMED) awaits the `vocab__` layer (D2) to map
+  the retained ICD-10 `condition_source_value`. Until then only the source code/name are
+  emitted.


### PR DESCRIPTION
## Summary

Adds `clinical__condition_occurrence`, the OMOP-lite `CONDITION_OCCURRENCE` domain — the first clinical **event** table hanging off the `visit_occurrence_id` hub. One row per encounter diagnosis.

- **FK graph (all tested):** `person_id` → `clinical__person` (AC-003), `visit_occurrence_id` → `clinical__visit_occurrence` (AC-004), `provider_id` → `ref__provider` (AC-005).
- **Source values:** ICD-10 `condition_source_value` (+ readable `condition_source_name`) from `reference_data` via `diagnosis_id`; `certainty` as `condition_status_source_value`; `is_primary` flag; `condition_type_source_value = 'encounter diagnosis'` (provenance).
- Point-in-time (no end date); soft-deleted / test-patient / `disproven`+`error` certainties filtered upstream in `bases/encounter_diagnoses`.

## Scoping decisions (documented as OQs)

- **Encounter diagnoses only (v1).** Program-registry conditions (`patient_program_registration_conditions`) are a differently-shaped second source (no encounter → no `visit_occurrence_id`, category-as-status) and are **OQ-1** — a planned `union all` branch with `condition_type_source_value = 'program registry'`.
- **`condition_concept_id` (SNOMED) deferred (OQ-2)** to the future `vocab__` layer — ICD→SNOMED needs the OMOP vocabulary tables, not a small `map__omop_*` seed. The ICD code is retained so the standard concept layers on cleanly later.

## Test plan

- Schema tests AC-001..006 (PK not_null/unique, three FK relationships, start_datetime not_null) — all pass locally against the dev DB. Demo data is sparse (1 encounter diagnosis) but exercises the full path (ICD code resolves; all FKs validate).

## Notes

- Depends on `ref__provider` (for the AC-005 provider FK), which is already on `clinical-and-ref-models`. Base is `clinical-and-ref-models` (the OMOP-lite integration branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)