### PR TITLE
feat(scripts): add import-reports-k8s scripts for Windows and macOS/Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must always use LF, even in a Windows working copy, or bash breaks
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ To import the compiled report definitions (and optionally a reporting schema) in
 central server running on Kubernetes, use the scripts in
 [scripts/import-reports/](scripts/import-reports/). There is a PowerShell version for
 Windows (`import-reports-k8s.ps1`) and an equivalent Bash version for macOS/Linux
-(`import-reports-k8s.sh`). Both default to a read-only plan and only write when re-run with
-`-Apply` / `--apply`. See [scripts/import-reports/README.md](scripts/import-reports/README.md)
-for prerequisites, options, and examples.
+(`import-reports-k8s.sh`). They switch the kubectl context first and **default to the
+demo cluster** (configurable via `--context` / `-Context`), and default to a read-only
+plan, only writing when re-run with `-Apply` / `--apply`. See
+[scripts/import-reports/README.md](scripts/import-reports/README.md) for prerequisites,
+options, and examples.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ To generate a report list:
 python list_tamanu_reports.py
 ```
 
+## Importing reports to a deployment
+
+To import the compiled report definitions (and optionally a reporting schema) into a
+central server running on Kubernetes, use the scripts in
+[scripts/import-reports/](scripts/import-reports/). There is a PowerShell version for
+Windows (`import-reports-k8s.ps1`) and an equivalent Bash version for macOS/Linux
+(`import-reports-k8s.sh`). Both default to a read-only plan and only write when re-run with
+`-Apply` / `--apply`. See [scripts/import-reports/README.md](scripts/import-reports/README.md)
+for prerequisites, options, and examples.
+
 ## Versioning
 
 We will use semantic versioning `< major >`.`< minor >`.`< patch >`. This number will mirror Tamanu's release

--- a/scripts/import-reports/README.md
+++ b/scripts/import-reports/README.md
@@ -1,0 +1,104 @@
+# import-reports
+
+Import Tamanu report definitions (and optionally a reporting schema) into a central
+server running on Kubernetes. This is **mechanical plumbing only** — the deployment
+runbook owns the decisions about *what* and *when*.
+
+Two equivalent scripts are provided so the same workflow runs on any machine:
+
+| Platform      | Script                | Run with          |
+| ------------- | --------------------- | ----------------- |
+| Windows       | `import-reports-k8s.ps1`  | PowerShell        |
+| macOS / Linux | `import-reports-k8s.sh`   | Bash              |
+
+Both take the same options and behave identically.
+
+## Prerequisites
+
+- `kubectl` on `PATH`, with your context pointed at the target cluster.
+- Access to the central-server pod (report import) and the CNPG `*-db-rw`
+  services (schema apply + snapshot).
+- The reporting-schema `.sql` file and/or the compiled report `.json` files you
+  want to import. Compiled reports are produced by the build in `compiled/reports/`.
+
+## Safety model: plan first, then apply
+
+The `importReport` CLI has **no dry run**, so these scripts default to a read-only
+**PLAN**: they resolve the pod, list what *would* be imported, and print the current
+report state. Nothing is written until you re-run with `-Apply` / `--apply`, which
+also prompts you to type the namespace back to confirm.
+
+## Usage
+
+### Windows (PowerShell)
+
+```powershell
+# Schema + reports — review the plan, then re-run with -Apply
+.\import-reports-k8s.ps1 -Namespace tamanu-syria-demo -ReportsDir .\my-reports `
+  -SchemaSql .\reporting-schema-v2.54.0-msf.sql `
+  -SchemaSvc central-db-rw,facility-1-db-rw `
+  -Workdir /app/packages/central-server
+
+# Reports only (schema already applied)
+.\import-reports-k8s.ps1 -Namespace tamanu-syria-demo -ReportsDir .\my-reports `
+  -Workdir /app/packages/central-server -Apply
+
+# Schema only, no report import
+.\import-reports-k8s.ps1 -Namespace tamanu-syria-demo `
+  -SchemaSql .\reporting-schema-v2.54.0-msf.sql `
+  -SchemaSvc central-db-rw,facility-1-db-rw -SchemaOnly
+```
+
+### macOS / Linux (Bash)
+
+```bash
+chmod +x import-reports-k8s.sh   # first time only
+
+# Schema + reports — review the plan, then re-run with --apply
+./import-reports-k8s.sh --namespace tamanu-syria-demo --reports-dir ./my-reports \
+  --schema-sql ./reporting-schema-v2.54.0-msf.sql \
+  --schema-svc central-db-rw,facility-1-db-rw \
+  --workdir /app/packages/central-server
+
+# Reports only (schema already applied)
+./import-reports-k8s.sh --namespace tamanu-syria-demo --reports-dir ./my-reports \
+  --workdir /app/packages/central-server --apply
+
+# Schema only, no report import
+./import-reports-k8s.sh --namespace tamanu-syria-demo \
+  --schema-sql ./reporting-schema-v2.54.0-msf.sql \
+  --schema-svc central-db-rw,facility-1-db-rw --schema-only
+```
+
+## Options
+
+| PowerShell        | Bash              | Default                              | Meaning |
+| ----------------- | ----------------- | ------------------------------------ | ------- |
+| `-Namespace` *(req)* | `--namespace` *(req)* | —                            | Target K8s namespace. |
+| `-ReportsDir`     | `--reports-dir`   | —                                    | Folder of `*.json` reports to import. Required unless schema-only. |
+| `-SchemaSql`      | `--schema-sql`    | —                                    | Reporting-schema `.sql` to apply first. Omit to import reports only. |
+| `-SchemaSvc`      | `--schema-svc`    | `central-db-rw`                      | Comma-separated `*-db-rw` services to apply the schema to. |
+| `-SchemaOnly`     | `--schema-only`   | off                                  | Apply the schema and skip report import (requires a schema file). |
+| `-Pod`            | `--pod`           | auto-resolved                        | Override the central pod instead of resolving by selector. |
+| `-Container`      | `--container`     | —                                    | Container name for multi-container pods. |
+| `-Selector`       | `--selector`      | `app.kubernetes.io/name=central,…`   | Label selector used to find the central pod. |
+| `-Workdir`        | `--workdir`       | `.`                                  | Working dir inside the pod for `node dist` (e.g. `/app/packages/central-server`). |
+| `-DbSvc`          | `--db-svc`        | `central-db-rw`                      | Service used for the before/after snapshot query. |
+| `-DbName`         | `--db-name`       | `app`                                | Database name. |
+| `-DbRole`         | `--db-role`       | `app`                                | Role the schema is applied as (`SET ROLE`). |
+| `-DbContainer`    | `--db-container`  | `postgres`                           | Postgres container name in the CNPG pod. |
+| `-Apply`          | `--apply`         | off (plan only)                      | Actually write. Prompts for namespace confirmation. |
+
+## What it does on apply
+
+1. **Schema first** (if `--schema-sql` given): for each `--schema-svc`, `exec` into the
+   CNPG `rw` service over its local socket (peer auth as the superuser), `SET ROLE` to
+   the app role, and apply the file in a single transaction.
+2. **Reports**: each `.json` is staged into the pod as base64 (immune to
+   encoding/newline truncation), the transferred byte count is verified against the
+   source (retried up to 3× on a short write), then imported with
+   `node dist importReport -f … -v`.
+3. **Snapshot** of report definitions and their latest/published versions is printed
+   before and after.
+
+After applying, verify per the runbook (active versions + spot-check that a report runs).

--- a/scripts/import-reports/README.md
+++ b/scripts/import-reports/README.md
@@ -104,8 +104,9 @@ chmod +x import-reports-k8s.sh   # first time only
 2. **Reports**: each `.json` is staged into the pod as base64 (immune to
    encoding/newline truncation), the transferred byte count is verified against the
    source (retried up to 3× on a short write), then imported with
-   `node dist importReport -f … -v`. The staged `/tmp/<name>.json` is removed after
-   each import.
+   `node dist importReport -f … -v`. On success the staged `/tmp/<name>.json` is removed;
+   if an import fails the run aborts and the file is deliberately left in the pod for
+   inspection / re-run.
 3. **Snapshot** of report definitions and their latest/published versions is printed
    before and after.
 

--- a/scripts/import-reports/README.md
+++ b/scripts/import-reports/README.md
@@ -4,6 +4,12 @@ Import Tamanu report definitions (and optionally a reporting schema) into a cent
 server running on Kubernetes. This is **mechanical plumbing only** — the deployment
 runbook owns the decisions about *what* and *when*.
 
+> **Cluster.** These scripts switch the active `kubectl` context before doing anything,
+> and **default to the demo cluster** (`--context demo` / `-Context demo`). They are
+> intended for the demo cluster; to target another cluster, pass `--context` / `-Context`
+> explicitly. The chosen context is printed at the top of the PLAN so you can confirm it
+> before applying.
+
 Two equivalent scripts are provided so the same workflow runs on any machine:
 
 | Platform      | Script                | Run with          |
@@ -87,6 +93,7 @@ chmod +x import-reports-k8s.sh   # first time only
 | `-DbName`         | `--db-name`       | `app`                                | Database name. |
 | `-DbRole`         | `--db-role`       | `app`                                | Role the schema is applied as (`SET ROLE`). |
 | `-DbContainer`    | `--db-container`  | `postgres`                           | Postgres container name in the CNPG pod. |
+| `-Context`        | `--context`       | `demo`                               | kubectl context switched to before any cluster call. Defaults to the demo cluster. |
 | `-Apply`          | `--apply`         | off (plan only)                      | Actually write. Prompts for namespace confirmation. |
 
 ## What it does on apply

--- a/scripts/import-reports/README.md
+++ b/scripts/import-reports/README.md
@@ -104,9 +104,9 @@ chmod +x import-reports-k8s.sh   # first time only
 2. **Reports**: each `.json` is staged into the pod as base64 (immune to
    encoding/newline truncation), the transferred byte count is verified against the
    source (retried up to 3× on a short write), then imported with
-   `node dist importReport -f … -v`. On success the staged `/tmp/<name>.json` is removed;
-   if an import fails the run aborts and the file is deliberately left in the pod for
-   inspection / re-run.
+   `node dist importReport -f … -v`. The staged `/tmp/<name>.json` is always removed
+   afterwards — on success and on failure alike — so nothing is left in the pod. If an
+   import fails, the run aborts with an error naming the report that failed.
 3. **Snapshot** of report definitions and their latest/published versions is printed
    before and after.
 

--- a/scripts/import-reports/README.md
+++ b/scripts/import-reports/README.md
@@ -97,8 +97,20 @@ chmod +x import-reports-k8s.sh   # first time only
 2. **Reports**: each `.json` is staged into the pod as base64 (immune to
    encoding/newline truncation), the transferred byte count is verified against the
    source (retried up to 3× on a short write), then imported with
-   `node dist importReport -f … -v`.
+   `node dist importReport -f … -v`. The staged `/tmp/<name>.json` is removed after
+   each import.
 3. **Snapshot** of report definitions and their latest/published versions is printed
    before and after.
 
 After applying, verify per the runbook (active versions + spot-check that a report runs).
+
+> **Note on the schema transfer.** The schema `.sql` is streamed over the same
+> `kubectl exec` stdin pipe as reports, but — unlike reports — it is *not* base64-staged
+> or byte-count-verified. The safety net there is `--single-transaction` +
+> `ON_ERROR_STOP=1`: a truncated file almost certainly fails to parse and the whole
+> transaction rolls back, so a short write aborts rather than partially applying. It
+> catches a bad transfer via the transaction, not by verifying the transfer itself.
+>
+> Report filenames must match `[A-Za-z0-9._-]+` (they are interpolated into a remote
+> shell command); the scripts reject anything outside that charset. Compiled report
+> names already conform.

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -245,6 +245,8 @@ if ($SchemaOnly) {
       Write-Host "   staged $bn is $size bytes, expected $expected (attempt $attempt/$maxStageAttempts); retrying"
     }
     if (-not $staged) {
+      # Drop the partial/failed temp file before aborting so nothing is left in the pod.
+      kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "rm -f '/tmp/$bn'" | Out-Null
       throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
     }
     # finally{} always removes the staged temp file, even if the import throws; catch{}

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -257,7 +257,9 @@ if ($SchemaOnly) {
       throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
     }
     Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
-    # Remove the staged temp file so nothing is left behind in the pod (best-effort).
+    # Clean up the staged temp file on the success path only. If importReport above fails,
+    # Invoke-NodeDist throws (ErrorActionPreference=Stop) before this line, deliberately
+    # leaving /tmp/$bn in the pod so you can inspect or re-run the import against it.
     kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "rm -f '/tmp/$bn'"
     if ($LASTEXITCODE -ne 0) { Write-Host "   (could not remove /tmp/$bn)" }
   }

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -123,7 +123,7 @@ function Invoke-PsqlSvc {
 }
 
 $snapshotSql = @"
-SELECT rd.name, rd.db_schema,
+SELECT rd.id AS definition_id, rd.name, rd.db_schema,
   max(rdv.version_number) AS latest,
   max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
 FROM report_definitions rd

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -5,6 +5,10 @@
   the runbook owns decisions.
 
 .DESCRIPTION
+  The active kubectl context is switched before any cluster call so the run targets the
+  intended cluster. It defaults to the demo cluster (-Context demo); pass -Context to
+  target a different cluster.
+
   Default mode is PLAN (read-only): resolves the pod, prints the current report state,
   and shows what WOULD be applied. Nothing is written until you pass -Apply. There is no
   native dry run on the importReport CLI, so this plan/apply split is the safety net.
@@ -53,6 +57,7 @@ param(
   [string]$DbName = "app",
   [string]$DbRole = "app",
   [string]$DbContainer = "postgres",
+  [string]$Context = "demo",
   [switch]$SchemaOnly,
   [switch]$Apply
 )
@@ -79,6 +84,14 @@ if (-not $SchemaOnly) {
   $reports = @(Get-ChildItem -LiteralPath $ReportsDir -Filter *.json -File | Sort-Object Name)
   if ($reports.Count -eq 0) { throw "ERROR: no .json files in $ReportsDir" }
 }
+
+# ---- switch cluster context -------------------------------------------------------
+# Switch the active kubectl context so every subsequent kubectl call (pod resolution,
+# snapshot, schema apply, report import) runs against the intended cluster, not whatever
+# context happened to be selected. Defaults to the demo cluster; override with -Context.
+Write-Host ">> Switching kubectl context to '$Context' ..."
+kubectl config use-context $Context
+Assert-LastExit "kubectl config use-context $Context"
 
 # ---- resolve the central pod (only needed for report import) ----------------------
 if (-not $SchemaOnly -and -not $Pod) {
@@ -133,6 +146,7 @@ $svcs = $SchemaSvc.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_
 
 Write-Host "=================================================================="
 Write-Host " PLAN"
+Write-Host "   kube context   : $Context"
 Write-Host "   namespace      : $Namespace"
 if ($SchemaOnly) {
   Write-Host "   central pod    : (skipped - schema-only run)"

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -1,0 +1,243 @@
+<#
+.SYNOPSIS
+  Import Tamanu report definitions (and optionally a reporting schema) into a central
+  server on K8s. PowerShell port of import-reports-k8s.sh. Mechanical plumbing only;
+  the runbook owns decisions.
+
+.DESCRIPTION
+  Default mode is PLAN (read-only): resolves the pod, prints the current report state,
+  and shows what WOULD be applied. Nothing is written until you pass -Apply. There is no
+  native dry run on the importReport CLI, so this plan/apply split is the safety net.
+
+  Reports to import: every *.json file in -ReportsDir.
+  Schema: optional. Pass -SchemaSql to apply a reporting-schema file first (CNPG socket
+  mode: exec into the rw Postgres service over its local socket with peer auth as the
+  superuser, SET ROLE to the app role, apply in one transaction). Omit -SchemaSql to skip
+  the schema step and only import reports. -SchemaSvc may list several services
+  (e.g. "central-db-rw,facility-1-db-rw").
+
+  Schema-only: pass -SchemaOnly (with -SchemaSql) to apply the schema and skip report
+  import entirely. -ReportsDir and the central pod are not needed in this mode.
+
+.EXAMPLE
+  .\import-reports-k8s.ps1 -Namespace tamanu-syria-demo -ReportsDir .\my-reports `
+    -SchemaSql .\reporting-schema-v2.54.0-msf.sql `
+    -SchemaSvc central-db-rw,facility-1-db-rw `
+    -Workdir /app/packages/central-server
+  # review the plan, then re-run with -Apply
+
+.EXAMPLE
+  # Reports only, schema already applied:
+  .\import-reports-k8s.ps1 -Namespace tamanu-syria-demo -ReportsDir .\my-reports `
+    -Workdir /app/packages/central-server -Apply
+
+.EXAMPLE
+  # Schema only, no report import:
+  .\import-reports-k8s.ps1 -Namespace tamanu-syria-demo `
+    -SchemaSql .\reporting-schema-v2.54.0-msf.sql `
+    -SchemaSvc central-db-rw,facility-1-db-rw -SchemaOnly
+  # review the plan, then re-run with -Apply
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$Namespace,
+  [string]$ReportsDir,
+  [string]$SchemaSql,
+  [string]$Pod,
+  [string]$Container,
+  [string]$Selector = "app.kubernetes.io/name=central,app.kubernetes.io/component=api-server",
+  [string]$Workdir = ".",
+  [string]$SchemaSvc = "central-db-rw",
+  [string]$DbSvc = "central-db-rw",
+  [string]$DbName = "app",
+  [string]$DbRole = "app",
+  [string]$DbContainer = "postgres",
+  [switch]$SchemaOnly,
+  [switch]$Apply
+)
+
+$ErrorActionPreference = "Stop"
+# Keep piped file content as UTF-8 without BOM (Win PowerShell 5.1 defaults to ASCII on this pipe)
+$OutputEncoding = New-Object System.Text.UTF8Encoding $false
+
+function Assert-LastExit([string]$What) {
+  if ($LASTEXITCODE -ne 0) { throw "ERROR: $What failed (exit $LASTEXITCODE)" }
+}
+
+# ---- validate inputs --------------------------------------------------------------
+if ($SchemaOnly -and -not $SchemaSql) {
+  throw "ERROR: -SchemaOnly requires -SchemaSql (there is nothing to apply otherwise)"
+}
+if ($SchemaSql -and -not (Test-Path -LiteralPath $SchemaSql)) {
+  throw "ERROR: schema SQL not found: $SchemaSql"
+}
+$reports = @()
+if (-not $SchemaOnly) {
+  if (-not $ReportsDir) { throw "ERROR: -ReportsDir is required unless -SchemaOnly is set" }
+  if (-not (Test-Path -LiteralPath $ReportsDir)) { throw "ERROR: reports dir not found: $ReportsDir" }
+  $reports = @(Get-ChildItem -LiteralPath $ReportsDir -Filter *.json -File | Sort-Object Name)
+  if ($reports.Count -eq 0) { throw "ERROR: no .json files in $ReportsDir" }
+}
+
+# ---- resolve the central pod (only needed for report import) ----------------------
+if (-not $SchemaOnly -and -not $Pod) {
+  $Pod = (kubectl get pods -n $Namespace -l $Selector --field-selector=status.phase=Running `
+          -o "jsonpath={.items[0].metadata.name}")
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($Pod)) {
+    throw "ERROR: could not resolve a Running central pod (pass -Pod)"
+  }
+}
+
+# -c only when a container was named (single-container pods do not need it)
+$cExec = @()
+if ($Container) { $cExec = @("-c", $Container) }
+
+function Invoke-NodeDist([string]$DistArgs) {
+  $inner = "cd '$Workdir' && node dist $DistArgs"
+  kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc $inner
+  Assert-LastExit "node dist $DistArgs"
+}
+
+# Socket-mode psql into a CNPG rw service (peer auth as superuser, no password)
+function Invoke-PsqlSvc {
+  param([string]$Svc, [string[]]$ExtraArgs, [string]$StdinFile)
+  $base = @("exec", "-i", "-n", $Namespace, "svc/$Svc", "-c", $DbContainer, "--",
+            "psql", "-d", $DbName, "-v", "ON_ERROR_STOP=1") + $ExtraArgs
+  if ($StdinFile) {
+    Get-Content -Raw -LiteralPath $StdinFile | kubectl @base
+  } else {
+    kubectl @base
+  }
+}
+
+$snapshotSql = @"
+SELECT rd.name, rd.db_schema,
+  max(rdv.version_number) AS latest,
+  max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
+FROM report_definitions rd
+LEFT JOIN report_definition_versions rdv
+  ON rdv.report_definition_id = rd.id AND rdv.deleted_at IS NULL
+WHERE rd.deleted_at IS NULL
+GROUP BY rd.id, rd.name, rd.db_schema
+ORDER BY rd.name;
+"@
+
+function Show-Snapshot {
+  Invoke-PsqlSvc -Svc $DbSvc -ExtraArgs @("-P", "pager=off", "-c", $snapshotSql)
+  if ($LASTEXITCODE -ne 0) { Write-Host "  (snapshot unavailable)" }
+}
+
+# ---- PLAN -------------------------------------------------------------------------
+$svcs = $SchemaSvc.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+Write-Host "=================================================================="
+Write-Host " PLAN"
+Write-Host "   namespace      : $Namespace"
+if ($SchemaOnly) {
+  Write-Host "   central pod    : (skipped - schema-only run)"
+} else {
+  $podLine = "   central pod    : $Pod"
+  if ($Container) { $podLine += "  (container: $Container)" }
+  Write-Host $podLine
+}
+if ($SchemaSql) {
+  Write-Host "   schema SQL     : $SchemaSql"
+  Write-Host "   schema -> svc  : $($svcs -join ', ')  (db=$DbName role=$DbRole container=$DbContainer)"
+} else {
+  Write-Host "   schema SQL     : (skipped - none provided)"
+}
+Write-Host "   snapshot svc   : $DbSvc"
+if ($SchemaOnly) {
+  Write-Host "   reports dir    : (skipped - schema-only run)"
+} else {
+  Write-Host "   reports dir    : $ReportsDir  ($($reports.Count) *.json files)"
+}
+Write-Host "------------------------------------------------------------------"
+if ($SchemaOnly) {
+  Write-Host " Reports: none (schema-only run)"
+} else {
+  Write-Host " Reports that WOULD be imported:"
+  foreach ($r in $reports) { Write-Host "   - $($r.Name)" }
+}
+Write-Host "------------------------------------------------------------------"
+Write-Host " Current report state (before):"
+Show-Snapshot
+Write-Host "=================================================================="
+
+if (-not $Apply) {
+  Write-Host "PLAN ONLY. Re-run with -Apply to write. Nothing was changed."
+  exit 0
+}
+
+# ---- APPLY guard ------------------------------------------------------------------
+Write-Host ""
+if ($SchemaOnly) {
+  Write-Host "About to APPLY schema to [$($svcs -join ', ')] into '$Namespace' (schema-only - no reports imported)."
+} elseif ($SchemaSql) {
+  Write-Host "About to APPLY schema to [$($svcs -join ', ')] and import $($reports.Count) reports into '$Namespace'."
+} else {
+  Write-Host "About to import $($reports.Count) reports into '$Namespace' (no schema step)."
+}
+Write-Host "This writes to the live database(s) and has NO dry run."
+$confirm = Read-Host "Type the namespace to confirm"
+if ($confirm -ne $Namespace) { throw "Confirmation did not match. Aborting." }
+
+# 1) Reporting schema FIRST (if provided), on each target service, as the app role
+if ($SchemaSql) {
+  foreach ($svc in $svcs) {
+    Write-Host ">> Applying reporting schema to svc/$svc as role $DbRole ..."
+    Invoke-PsqlSvc -Svc $svc `
+      -ExtraArgs @("--single-transaction", "-c", "SET ROLE $DbRole", "-f", "-") `
+      -StdinFile $SchemaSql
+    Assert-LastExit "schema apply to svc/$svc"
+  }
+  Write-Host ">> Schema applied."
+} else {
+  Write-Host ">> No schema file provided; skipping schema step."
+}
+
+# 2) Import each report (skipped on a schema-only run)
+if ($SchemaOnly) {
+  Write-Host ">> Schema-only run; skipping report import."
+} else {
+  $maxStageAttempts = 3
+  foreach ($r in $reports) {
+    $bn = $r.Name
+    Write-Host ">> Importing $bn ..."
+    # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
+    # that silently produced empty files with a raw `Get-Content | cat >` pipe).
+    # The streamed stdin pipe can occasionally short-write over the network, so retry
+    # the stage+verify a few times; a transient truncation self-heals instead of
+    # aborting the whole run.
+    $expected = (Get-Item -LiteralPath $r.FullName).Length
+    $b64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($r.FullName))
+    $staged = $false
+    for ($attempt = 1; $attempt -le $maxStageAttempts; $attempt++) {
+      $b64 | kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "base64 -d > '/tmp/$bn'"
+      if ($LASTEXITCODE -ne 0) {
+        Write-Host "   stage attempt $attempt/$maxStageAttempts failed (kubectl exit $LASTEXITCODE)"
+        continue
+      }
+      # Verify the staged file is intact before importing (catches a truncated transfer).
+      $size = (kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "wc -c < '/tmp/$bn'").Trim()
+      if ($LASTEXITCODE -ne 0) {
+        Write-Host "   verify attempt $attempt/$maxStageAttempts failed (kubectl exit $LASTEXITCODE)"
+        continue
+      }
+      if ($size -eq "$expected") { $staged = $true; break }
+      Write-Host "   staged $bn is $size bytes, expected $expected (attempt $attempt/$maxStageAttempts); retrying"
+    }
+    if (-not $staged) {
+      throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
+    }
+    Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
+  }
+}
+
+# 3) After snapshot
+Write-Host "------------------------------------------------------------------"
+Write-Host " Current report state (after):"
+Show-Snapshot
+Write-Host "=================================================================="
+Write-Host "DONE. Verify per the runbook (active versions + spot-check a report runs)."

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -123,7 +123,7 @@ function Invoke-PsqlSvc {
 }
 
 $snapshotSql = @"
-SELECT rd.id AS definition_id, rd.name, rd.db_schema,
+SELECT rd.id, rd.name, rd.db_schema,
   max(rdv.version_number) AS latest,
   max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
 FROM report_definitions rd

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -184,6 +184,11 @@ $confirm = Read-Host "Type the namespace to confirm"
 if ($confirm -ne $Namespace) { throw "Confirmation did not match. Aborting." }
 
 # 1) Reporting schema FIRST (if provided), on each target service, as the app role
+# NOTE: the schema is streamed over the same kubectl stdin pipe that can short-write
+# on the network, but unlike reports it is NOT base64-verified. --single-transaction
+# + ON_ERROR_STOP=1 is the safety net: a truncated file almost certainly fails to parse
+# and the whole transaction rolls back, so a short write aborts rather than partially
+# applying. It does not verify the transfer itself.
 if ($SchemaSql) {
   foreach ($svc in $svcs) {
     Write-Host ">> Applying reporting schema to svc/$svc as role $DbRole ..."
@@ -204,6 +209,12 @@ if ($SchemaOnly) {
   $maxStageAttempts = 3
   foreach ($r in $reports) {
     $bn = $r.Name
+    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`, so reject anything
+    # outside a safe charset to keep the single-quoting intact (compiled report names
+    # are controlled, but a stray quote or space would break the command).
+    if ($bn -notmatch '^[A-Za-z0-9._-]+$') {
+      throw "ERROR: unsafe report filename: $bn (allowed: A-Z a-z 0-9 . _ -)"
+    }
     Write-Host ">> Importing $bn ..."
     # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
     # that silently produced empty files with a raw `Get-Content | cat >` pipe).
@@ -232,6 +243,9 @@ if ($SchemaOnly) {
       throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
     }
     Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
+    # Remove the staged temp file so nothing is left behind in the pod (best-effort).
+    kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "rm -f '/tmp/$bn'"
+    if ($LASTEXITCODE -ne 0) { Write-Host "   (could not remove /tmp/$bn)" }
   }
 }
 

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -86,9 +86,7 @@ if (-not $SchemaOnly) {
 }
 
 # ---- switch cluster context -------------------------------------------------------
-# Switch the active kubectl context so every subsequent kubectl call (pod resolution,
-# snapshot, schema apply, report import) runs against the intended cluster, not whatever
-# context happened to be selected. Defaults to the demo cluster; override with -Context.
+# So every kubectl call runs against the intended cluster, not whatever was selected.
 Write-Host ">> Switching kubectl context to '$Context' ..."
 kubectl config use-context $Context
 Assert-LastExit "kubectl config use-context $Context"
@@ -197,12 +195,9 @@ Write-Host "This writes to the live database(s) and has NO dry run."
 $confirm = Read-Host "Type the namespace to confirm"
 if ($confirm -ne $Namespace) { throw "Confirmation did not match. Aborting." }
 
-# 1) Reporting schema FIRST (if provided), on each target service, as the app role
-# NOTE: the schema is streamed over the same kubectl stdin pipe that can short-write
-# on the network, but unlike reports it is NOT base64-verified. --single-transaction
-# + ON_ERROR_STOP=1 is the safety net: a truncated file almost certainly fails to parse
-# and the whole transaction rolls back, so a short write aborts rather than partially
-# applying. It does not verify the transfer itself.
+# 1) Reporting schema FIRST (if provided), on each target service, as the app role.
+# Unlike reports the schema is not byte-count-verified; --single-transaction +
+# ON_ERROR_STOP=1 is the safety net, so a short write fails to parse and rolls back.
 if ($SchemaSql) {
   foreach ($svc in $svcs) {
     Write-Host ">> Applying reporting schema to svc/$svc as role $DbRole ..."
@@ -223,18 +218,14 @@ if ($SchemaOnly) {
   $maxStageAttempts = 3
   foreach ($r in $reports) {
     $bn = $r.Name
-    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`, so reject anything
-    # outside a safe charset to keep the single-quoting intact (compiled report names
-    # are controlled, but a stray quote or space would break the command).
+    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`; reject anything outside
+    # a safe charset so a stray quote or space can't break the quoting.
     if ($bn -notmatch '^[A-Za-z0-9._-]+$') {
       throw "ERROR: unsafe report filename: $bn (allowed: A-Z a-z 0-9 . _ -)"
     }
     Write-Host ">> Importing $bn ..."
-    # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
-    # that silently produced empty files with a raw `Get-Content | cat >` pipe).
-    # The streamed stdin pipe can occasionally short-write over the network, so retry
-    # the stage+verify a few times; a transient truncation self-heals instead of
-    # aborting the whole run.
+    # Stage as base64 (pure ASCII, immune to newline/encoding truncation), then verify the
+    # byte count and retry — the stdin pipe can short-write over the network.
     $expected = (Get-Item -LiteralPath $r.FullName).Length
     $b64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($r.FullName))
     $staged = $false
@@ -256,9 +247,8 @@ if ($SchemaOnly) {
     if (-not $staged) {
       throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
     }
-    # finally{} ALWAYS removes the staged temp file (Option B) — even if the import throws
-    # — so nothing is left in the pod. catch{} re-throws with the report name so the CLI
-    # says which report failed.
+    # finally{} always removes the staged temp file, even if the import throws; catch{}
+    # re-throws naming the report so the CLI says which one failed.
     try {
       Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
     } catch {

--- a/scripts/import-reports/import-reports-k8s.ps1
+++ b/scripts/import-reports/import-reports-k8s.ps1
@@ -256,12 +256,17 @@ if ($SchemaOnly) {
     if (-not $staged) {
       throw "ERROR: failed to stage $bn intact after $maxStageAttempts attempts (expected $expected bytes). Aborting."
     }
-    Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
-    # Clean up the staged temp file on the success path only. If importReport above fails,
-    # Invoke-NodeDist throws (ErrorActionPreference=Stop) before this line, deliberately
-    # leaving /tmp/$bn in the pod so you can inspect or re-run the import against it.
-    kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "rm -f '/tmp/$bn'"
-    if ($LASTEXITCODE -ne 0) { Write-Host "   (could not remove /tmp/$bn)" }
+    # finally{} ALWAYS removes the staged temp file (Option B) — even if the import throws
+    # — so nothing is left in the pod. catch{} re-throws with the report name so the CLI
+    # says which report failed.
+    try {
+      Invoke-NodeDist "importReport -f '/tmp/$bn' -v"
+    } catch {
+      throw "ERROR: importReport failed for $bn. Aborting. ($_)"
+    } finally {
+      kubectl exec -i -n $Namespace $Pod @cExec -- sh -lc "rm -f '/tmp/$bn'"
+      if ($LASTEXITCODE -ne 0) { Write-Host "   (could not remove /tmp/$bn)" }
+    }
   }
 }
 

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -324,12 +324,17 @@ else
       echo "ERROR: failed to stage $bn intact after $max_stage_attempts attempts (expected $expected bytes). Aborting." >&2
       exit 1
     fi
-    invoke_node_dist "importReport -f '/tmp/$bn' -v"
-    # Clean up the staged temp file on the success path only. If importReport above fails,
-    # `set -e` aborts the run before this line, deliberately leaving /tmp/$bn in the pod so
-    # you can inspect or re-run the import against it. The `|| echo` only reports an rm error.
+    # Capture the import exit rather than letting `set -e` abort mid-loop, so we can
+    # ALWAYS remove the staged temp file afterwards (Option B) — on success and failure
+    # alike — then fail loudly naming the report.
+    import_rc=0
+    invoke_node_dist "importReport -f '/tmp/$bn' -v" || import_rc=$?
     kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
       sh -lc "rm -f '/tmp/$bn'" || echo "   (could not remove /tmp/$bn)"
+    if [[ $import_rc -ne 0 ]]; then
+      echo "ERROR: importReport failed for $bn (exit $import_rc). Aborting." >&2
+      exit 1
+    fi
   done
 fi
 

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -252,6 +252,11 @@ read -r -p "Type the namespace to confirm: " confirm
 [[ "$confirm" == "$NAMESPACE" ]] || { echo "Confirmation did not match. Aborting." >&2; exit 1; }
 
 # 1) Reporting schema FIRST (if provided), on each target service, as the app role
+# NOTE: the schema is streamed over the same kubectl stdin pipe that can short-write
+# on the network, but unlike reports it is NOT base64-verified. --single-transaction
+# + ON_ERROR_STOP=1 is the safety net: a truncated file almost certainly fails to parse
+# and the whole transaction rolls back, so a short write aborts rather than partially
+# applying. It does not verify the transfer itself.
 if [[ -n "$SCHEMA_SQL" ]]; then
   for svc in "${svcs[@]}"; do
     echo ">> Applying reporting schema to svc/$svc as role $DB_ROLE ..."
@@ -270,6 +275,12 @@ else
   max_stage_attempts=3
   for r in "${reports[@]}"; do
     bn="$(basename "$r")"
+    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`, so reject anything
+    # outside a safe charset to keep the single-quoting intact (compiled report names
+    # are controlled, but a stray quote or space would break the command).
+    case "$bn" in
+      *[!A-Za-z0-9._-]*) echo "ERROR: unsafe report filename: $bn (allowed: A-Z a-z 0-9 . _ -)" >&2; exit 1 ;;
+    esac
     echo ">> Importing $bn ..."
     # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
     # that silently produced empty files with a raw `cat | cat >` pipe).
@@ -299,6 +310,9 @@ else
       exit 1
     fi
     invoke_node_dist "importReport -f '/tmp/$bn' -v"
+    # Remove the staged temp file so nothing is left behind in the pod (best-effort).
+    kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
+      sh -lc "rm -f '/tmp/$bn'" || echo "   (could not remove /tmp/$bn)"
   done
 fi
 

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -325,7 +325,9 @@ else
       exit 1
     fi
     invoke_node_dist "importReport -f '/tmp/$bn' -v"
-    # Remove the staged temp file so nothing is left behind in the pod (best-effort).
+    # Clean up the staged temp file on the success path only. If importReport above fails,
+    # `set -e` aborts the run before this line, deliberately leaving /tmp/$bn in the pod so
+    # you can inspect or re-run the import against it. The `|| echo` only reports an rm error.
     kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
       sh -lc "rm -f '/tmp/$bn'" || echo "   (could not remove /tmp/$bn)"
   done

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -6,6 +6,10 @@
 # server on K8s. Mechanical plumbing only; the runbook owns decisions. This is the
 # macOS/Linux counterpart of import-reports-k8s.ps1 and behaves identically.
 #
+# The active kubectl context is switched before any cluster call so the run targets the
+# intended cluster. It defaults to the demo cluster (--context demo); pass --context to
+# target a different cluster.
+#
 # Default mode is PLAN (read-only): resolves the pod, prints the current report state,
 # and shows what WOULD be applied. Nothing is written until you pass --apply. There is no
 # native dry run on the importReport CLI, so this plan/apply split is the safety net.
@@ -61,6 +65,7 @@ Options:
   --db-name NAME       database name (default: app)
   --db-role ROLE       role the schema is applied as via SET ROLE (default: app)
   --db-container NAME  Postgres container in the CNPG pod (default: postgres)
+  --context NAME       kubectl context to switch to first (default: demo)
   --apply              actually write (prompts for namespace confirmation)
   -h, --help           show this help
 
@@ -82,6 +87,7 @@ DB_SVC="central-db-rw"
 DB_NAME="app"
 DB_ROLE="app"
 DB_CONTAINER="postgres"
+CONTEXT="demo"
 SCHEMA_ONLY=false
 APPLY=false
 
@@ -100,6 +106,7 @@ while [[ $# -gt 0 ]]; do
     --db-name)       DB_NAME="$2"; shift 2 ;;
     --db-role)       DB_ROLE="$2"; shift 2 ;;
     --db-container)  DB_CONTAINER="$2"; shift 2 ;;
+    --context)       CONTEXT="$2"; shift 2 ;;
     --schema-only)   SCHEMA_ONLY=true; shift ;;
     --apply)         APPLY=true; shift ;;
     -h|--help)       usage 0 ;;
@@ -135,6 +142,13 @@ if ! $SCHEMA_ONLY; then
   shopt -u nullglob
   [[ ${#reports[@]} -gt 0 ]] || { echo "ERROR: no .json files in $REPORTS_DIR" >&2; exit 1; }
 fi
+
+# ---- switch cluster context -------------------------------------------------------
+# Switch the active kubectl context so every subsequent kubectl call (pod resolution,
+# snapshot, schema apply, report import) runs against the intended cluster, not whatever
+# context happened to be selected. Defaults to the demo cluster; override with --context.
+echo ">> Switching kubectl context to '$CONTEXT' ..."
+kubectl config use-context "$CONTEXT"
 
 # ---- resolve the central pod (only needed for report import) ----------------------
 if ! $SCHEMA_ONLY && [[ -z "$POD" ]]; then
@@ -201,6 +215,7 @@ svcs_joined="$(IFS=', '; echo "${svcs[*]}")"
 
 echo "=================================================================="
 echo " PLAN"
+echo "   kube context   : $CONTEXT"
 echo "   namespace      : $NAMESPACE"
 if $SCHEMA_ONLY; then
   echo "   central pod    : (skipped - schema-only run)"

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# import-reports-k8s.sh
+#
+# Import Tamanu report definitions (and optionally a reporting schema) into a central
+# server on K8s. Mechanical plumbing only; the runbook owns decisions. This is the
+# macOS/Linux counterpart of import-reports-k8s.ps1 and behaves identically.
+#
+# Default mode is PLAN (read-only): resolves the pod, prints the current report state,
+# and shows what WOULD be applied. Nothing is written until you pass --apply. There is no
+# native dry run on the importReport CLI, so this plan/apply split is the safety net.
+#
+#   Reports to import: every *.json file in --reports-dir.
+#   Schema: optional. Pass --schema-sql to apply a reporting-schema file first (CNPG socket
+#   mode: exec into the rw Postgres service over its local socket with peer auth as the
+#   superuser, SET ROLE to the app role, apply in one transaction). Omit --schema-sql to
+#   skip the schema step and only import reports. --schema-svc may list several services
+#   (e.g. "central-db-rw,facility-1-db-rw").
+#
+#   Schema-only: pass --schema-only (with --schema-sql) to apply the schema and skip report
+#   import entirely. --reports-dir and the central pod are not needed in this mode.
+#
+# EXAMPLES
+#   # Schema + reports, review the plan, then re-run with --apply:
+#   ./import-reports-k8s.sh --namespace tamanu-syria-demo --reports-dir ./my-reports \
+#     --schema-sql ./reporting-schema-v2.54.0-msf.sql \
+#     --schema-svc central-db-rw,facility-1-db-rw \
+#     --workdir /app/packages/central-server
+#
+#   # Reports only, schema already applied:
+#   ./import-reports-k8s.sh --namespace tamanu-syria-demo --reports-dir ./my-reports \
+#     --workdir /app/packages/central-server --apply
+#
+#   # Schema only, no report import:
+#   ./import-reports-k8s.sh --namespace tamanu-syria-demo \
+#     --schema-sql ./reporting-schema-v2.54.0-msf.sql \
+#     --schema-svc central-db-rw,facility-1-db-rw --schema-only
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# ---- defaults (mirror the PowerShell param block) ---------------------------------
+NAMESPACE=""
+REPORTS_DIR=""
+SCHEMA_SQL=""
+POD=""
+CONTAINER=""
+SELECTOR="app.kubernetes.io/name=central,app.kubernetes.io/component=api-server"
+WORKDIR="."
+SCHEMA_SVC="central-db-rw"
+DB_SVC="central-db-rw"
+DB_NAME="app"
+DB_ROLE="app"
+DB_CONTAINER="postgres"
+SCHEMA_ONLY=false
+APPLY=false
+
+# ---- parse args -------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)     NAMESPACE="$2"; shift 2 ;;
+    --reports-dir)   REPORTS_DIR="$2"; shift 2 ;;
+    --schema-sql)    SCHEMA_SQL="$2"; shift 2 ;;
+    --pod)           POD="$2"; shift 2 ;;
+    --container)     CONTAINER="$2"; shift 2 ;;
+    --selector)      SELECTOR="$2"; shift 2 ;;
+    --workdir)       WORKDIR="$2"; shift 2 ;;
+    --schema-svc)    SCHEMA_SVC="$2"; shift 2 ;;
+    --db-svc)        DB_SVC="$2"; shift 2 ;;
+    --db-name)       DB_NAME="$2"; shift 2 ;;
+    --db-role)       DB_ROLE="$2"; shift 2 ;;
+    --db-container)  DB_CONTAINER="$2"; shift 2 ;;
+    --schema-only)   SCHEMA_ONLY=true; shift ;;
+    --apply)         APPLY=true; shift ;;
+    -h|--help)       usage 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+[[ -n "$NAMESPACE" ]] || { echo "ERROR: --namespace is required" >&2; usage 1; }
+
+# -c only when a container was named (single-container pods do not need it)
+cexec=()
+[[ -n "$CONTAINER" ]] && cexec=(-c "$CONTAINER")
+
+# ---- validate inputs --------------------------------------------------------------
+if $SCHEMA_ONLY && [[ -z "$SCHEMA_SQL" ]]; then
+  echo "ERROR: --schema-only requires --schema-sql (there is nothing to apply otherwise)" >&2
+  exit 1
+fi
+if [[ -n "$SCHEMA_SQL" && ! -f "$SCHEMA_SQL" ]]; then
+  echo "ERROR: schema SQL not found: $SCHEMA_SQL" >&2
+  exit 1
+fi
+
+reports=()
+if ! $SCHEMA_ONLY; then
+  [[ -n "$REPORTS_DIR" ]] || { echo "ERROR: --reports-dir is required unless --schema-only is set" >&2; exit 1; }
+  [[ -d "$REPORTS_DIR" ]] || { echo "ERROR: reports dir not found: $REPORTS_DIR" >&2; exit 1; }
+  # Collect *.json sorted by name (nullglob so a no-match glob yields nothing).
+  shopt -s nullglob
+  while IFS= read -r f; do reports+=("$f"); done < <(
+    for j in "$REPORTS_DIR"/*.json; do echo "$j"; done | sort
+  )
+  shopt -u nullglob
+  [[ ${#reports[@]} -gt 0 ]] || { echo "ERROR: no .json files in $REPORTS_DIR" >&2; exit 1; }
+fi
+
+# ---- resolve the central pod (only needed for report import) ----------------------
+if ! $SCHEMA_ONLY && [[ -z "$POD" ]]; then
+  POD="$(kubectl get pods -n "$NAMESPACE" -l "$SELECTOR" --field-selector=status.phase=Running \
+         -o "jsonpath={.items[0].metadata.name}")"
+  if [[ -z "${POD// }" ]]; then
+    echo "ERROR: could not resolve a Running central pod (pass --pod)" >&2
+    exit 1
+  fi
+fi
+
+# ---- helpers ----------------------------------------------------------------------
+invoke_node_dist() {
+  # $1 = args passed to `node dist`
+  local dist_args="$1"
+  kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- sh -lc "cd '$WORKDIR' && node dist $dist_args"
+}
+
+# Socket-mode psql into a CNPG rw service (peer auth as superuser, no password).
+# Usage: invoke_psql_svc <svc> [--stdin-file <path>] -- <extra psql args...>
+invoke_psql_svc() {
+  local svc="$1"; shift
+  local stdin_file=""
+  if [[ "${1:-}" == "--stdin-file" ]]; then
+    stdin_file="$2"; shift 2
+  fi
+  [[ "${1:-}" == "--" ]] && shift
+  local base=(exec -i -n "$NAMESPACE" "svc/$svc" -c "$DB_CONTAINER" --
+              psql -d "$DB_NAME" -v ON_ERROR_STOP=1 "$@")
+  if [[ -n "$stdin_file" ]]; then
+    kubectl "${base[@]}" < "$stdin_file"
+  else
+    kubectl "${base[@]}"
+  fi
+}
+
+read -r -d '' SNAPSHOT_SQL <<'SQL' || true
+SELECT rd.name, rd.db_schema,
+  max(rdv.version_number) AS latest,
+  max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
+FROM report_definitions rd
+LEFT JOIN report_definition_versions rdv
+  ON rdv.report_definition_id = rd.id AND rdv.deleted_at IS NULL
+WHERE rd.deleted_at IS NULL
+GROUP BY rd.id, rd.name, rd.db_schema
+ORDER BY rd.name;
+SQL
+
+show_snapshot() {
+  invoke_psql_svc "$DB_SVC" -- -P pager=off -c "$SNAPSHOT_SQL" \
+    || echo "  (snapshot unavailable)"
+}
+
+# ---- PLAN -------------------------------------------------------------------------
+# Split SCHEMA_SVC on commas, trim, drop empties.
+svcs=()
+IFS=',' read -ra _raw_svcs <<< "$SCHEMA_SVC"
+for s in "${_raw_svcs[@]}"; do
+  s="$(echo "$s" | tr -d '[:space:]')"
+  [[ -n "$s" ]] && svcs+=("$s")
+done
+svcs_joined="$(IFS=', '; echo "${svcs[*]}")"
+
+echo "=================================================================="
+echo " PLAN"
+echo "   namespace      : $NAMESPACE"
+if $SCHEMA_ONLY; then
+  echo "   central pod    : (skipped - schema-only run)"
+else
+  pod_line="   central pod    : $POD"
+  [[ -n "$CONTAINER" ]] && pod_line="$pod_line  (container: $CONTAINER)"
+  echo "$pod_line"
+fi
+if [[ -n "$SCHEMA_SQL" ]]; then
+  echo "   schema SQL     : $SCHEMA_SQL"
+  echo "   schema -> svc  : $svcs_joined  (db=$DB_NAME role=$DB_ROLE container=$DB_CONTAINER)"
+else
+  echo "   schema SQL     : (skipped - none provided)"
+fi
+echo "   snapshot svc   : $DB_SVC"
+if $SCHEMA_ONLY; then
+  echo "   reports dir    : (skipped - schema-only run)"
+else
+  echo "   reports dir    : $REPORTS_DIR  (${#reports[@]} *.json files)"
+fi
+echo "------------------------------------------------------------------"
+if $SCHEMA_ONLY; then
+  echo " Reports: none (schema-only run)"
+else
+  echo " Reports that WOULD be imported:"
+  for r in "${reports[@]}"; do echo "   - $(basename "$r")"; done
+fi
+echo "------------------------------------------------------------------"
+echo " Current report state (before):"
+show_snapshot
+echo "=================================================================="
+
+if ! $APPLY; then
+  echo "PLAN ONLY. Re-run with --apply to write. Nothing was changed."
+  exit 0
+fi
+
+# ---- APPLY guard ------------------------------------------------------------------
+echo ""
+if $SCHEMA_ONLY; then
+  echo "About to APPLY schema to [$svcs_joined] into '$NAMESPACE' (schema-only - no reports imported)."
+elif [[ -n "$SCHEMA_SQL" ]]; then
+  echo "About to APPLY schema to [$svcs_joined] and import ${#reports[@]} reports into '$NAMESPACE'."
+else
+  echo "About to import ${#reports[@]} reports into '$NAMESPACE' (no schema step)."
+fi
+echo "This writes to the live database(s) and has NO dry run."
+read -r -p "Type the namespace to confirm: " confirm
+[[ "$confirm" == "$NAMESPACE" ]] || { echo "Confirmation did not match. Aborting." >&2; exit 1; }
+
+# 1) Reporting schema FIRST (if provided), on each target service, as the app role
+if [[ -n "$SCHEMA_SQL" ]]; then
+  for svc in "${svcs[@]}"; do
+    echo ">> Applying reporting schema to svc/$svc as role $DB_ROLE ..."
+    invoke_psql_svc "$svc" --stdin-file "$SCHEMA_SQL" -- \
+      --single-transaction -c "SET ROLE $DB_ROLE" -f -
+  done
+  echo ">> Schema applied."
+else
+  echo ">> No schema file provided; skipping schema step."
+fi
+
+# 2) Import each report (skipped on a schema-only run)
+if $SCHEMA_ONLY; then
+  echo ">> Schema-only run; skipping report import."
+else
+  max_stage_attempts=3
+  for r in "${reports[@]}"; do
+    bn="$(basename "$r")"
+    echo ">> Importing $bn ..."
+    # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
+    # that silently produced empty files with a raw `cat | cat >` pipe).
+    # The streamed stdin pipe can occasionally short-write over the network, so retry
+    # the stage+verify a few times; a transient truncation self-heals instead of
+    # aborting the whole run.
+    expected="$(wc -c < "$r" | tr -d '[:space:]')"
+    staged=false
+    for ((attempt = 1; attempt <= max_stage_attempts; attempt++)); do
+      if ! base64 < "$r" | kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- \
+             sh -lc "base64 -d > '/tmp/$bn'"; then
+        echo "   stage attempt $attempt/$max_stage_attempts failed (kubectl error)"
+        continue
+      fi
+      # Verify the staged file is intact before importing (catches a truncated transfer).
+      if ! size="$(kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- \
+                   sh -lc "wc -c < '/tmp/$bn'")"; then
+        echo "   verify attempt $attempt/$max_stage_attempts failed (kubectl error)"
+        continue
+      fi
+      size="$(echo "$size" | tr -d '[:space:]')"
+      if [[ "$size" == "$expected" ]]; then staged=true; break; fi
+      echo "   staged $bn is $size bytes, expected $expected (attempt $attempt/$max_stage_attempts); retrying"
+    done
+    if ! $staged; then
+      echo "ERROR: failed to stage $bn intact after $max_stage_attempts attempts (expected $expected bytes). Aborting." >&2
+      exit 1
+    fi
+    invoke_node_dist "importReport -f '/tmp/$bn' -v"
+  done
+fi
+
+# 3) After snapshot
+echo "------------------------------------------------------------------"
+echo " Current report state (after):"
+show_snapshot
+echo "=================================================================="
+echo "DONE. Verify per the runbook (active versions + spot-check a report runs)."

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -144,9 +144,7 @@ if ! $SCHEMA_ONLY; then
 fi
 
 # ---- switch cluster context -------------------------------------------------------
-# Switch the active kubectl context so every subsequent kubectl call (pod resolution,
-# snapshot, schema apply, report import) runs against the intended cluster, not whatever
-# context happened to be selected. Defaults to the demo cluster; override with --context.
+# So every kubectl call runs against the intended cluster, not whatever was selected.
 echo ">> Switching kubectl context to '$CONTEXT' ..."
 kubectl config use-context "$CONTEXT"
 
@@ -266,12 +264,9 @@ echo "This writes to the live database(s) and has NO dry run."
 read -r -p "Type the namespace to confirm: " confirm
 [[ "$confirm" == "$NAMESPACE" ]] || { echo "Confirmation did not match. Aborting." >&2; exit 1; }
 
-# 1) Reporting schema FIRST (if provided), on each target service, as the app role
-# NOTE: the schema is streamed over the same kubectl stdin pipe that can short-write
-# on the network, but unlike reports it is NOT base64-verified. --single-transaction
-# + ON_ERROR_STOP=1 is the safety net: a truncated file almost certainly fails to parse
-# and the whole transaction rolls back, so a short write aborts rather than partially
-# applying. It does not verify the transfer itself.
+# 1) Reporting schema FIRST (if provided), on each target service, as the app role.
+# Unlike reports the schema is not byte-count-verified; --single-transaction +
+# ON_ERROR_STOP=1 is the safety net, so a short write fails to parse and rolls back.
 if [[ -n "$SCHEMA_SQL" ]]; then
   for svc in "${svcs[@]}"; do
     echo ">> Applying reporting schema to svc/$svc as role $DB_ROLE ..."
@@ -290,18 +285,14 @@ else
   max_stage_attempts=3
   for r in "${reports[@]}"; do
     bn="$(basename "$r")"
-    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`, so reject anything
-    # outside a safe charset to keep the single-quoting intact (compiled report names
-    # are controlled, but a stray quote or space would break the command).
+    # $bn is interpolated into a remote `sh -lc "... '/tmp/$bn'"`; reject anything outside
+    # a safe charset so a stray quote or space can't break the quoting.
     case "$bn" in
       *[!A-Za-z0-9._-]*) echo "ERROR: unsafe report filename: $bn (allowed: A-Z a-z 0-9 . _ -)" >&2; exit 1 ;;
     esac
     echo ">> Importing $bn ..."
-    # Stage via base64 (pure ASCII; immune to encoding/newline/stdin-flush truncation
-    # that silently produced empty files with a raw `cat | cat >` pipe).
-    # The streamed stdin pipe can occasionally short-write over the network, so retry
-    # the stage+verify a few times; a transient truncation self-heals instead of
-    # aborting the whole run.
+    # Stage as base64 (pure ASCII, immune to newline/encoding truncation), then verify the
+    # byte count and retry — the stdin pipe can short-write over the network.
     expected="$(wc -c < "$r" | tr -d '[:space:]')"
     staged=false
     for ((attempt = 1; attempt <= max_stage_attempts; attempt++)); do
@@ -324,9 +315,8 @@ else
       echo "ERROR: failed to stage $bn intact after $max_stage_attempts attempts (expected $expected bytes). Aborting." >&2
       exit 1
     fi
-    # Capture the import exit rather than letting `set -e` abort mid-loop, so we can
-    # ALWAYS remove the staged temp file afterwards (Option B) — on success and failure
-    # alike — then fail loudly naming the report.
+    # Capture the exit so `set -e` doesn't abort before cleanup; always remove the staged
+    # temp file, then fail loudly naming the report.
     import_rc=0
     invoke_node_dist "importReport -f '/tmp/$bn' -v" || import_rc=$?
     kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -39,7 +39,33 @@
 set -euo pipefail
 
 usage() {
-  sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+import-reports-k8s.sh — import Tamanu reports (and optionally a reporting schema)
+into a central server on K8s. Defaults to a read-only PLAN; nothing is written
+until you pass --apply. macOS/Linux counterpart of import-reports-k8s.ps1.
+
+Usage:
+  import-reports-k8s.sh --namespace NS [options] [--apply]
+
+Options:
+  --namespace NS       (required) target K8s namespace
+  --reports-dir DIR    folder of *.json reports (required unless --schema-only)
+  --schema-sql FILE    reporting-schema .sql to apply first (omit to skip schema)
+  --schema-svc LIST    comma-separated *-db-rw services for schema (default: central-db-rw)
+  --schema-only        apply schema only, skip report import (requires --schema-sql)
+  --pod NAME           override the central pod (default: resolve by --selector)
+  --container NAME     container name for multi-container pods
+  --selector SEL       label selector to find the central pod
+  --workdir DIR        working dir in the pod for `node dist` (default: .)
+  --db-svc SVC         service used for the before/after snapshot (default: central-db-rw)
+  --db-name NAME       database name (default: app)
+  --db-role ROLE       role the schema is applied as via SET ROLE (default: app)
+  --db-container NAME  Postgres container in the CNPG pod (default: postgres)
+  --apply              actually write (prompts for namespace confirmation)
+  -h, --help           show this help
+
+See scripts/import-reports/README.md for details and examples.
+EOF
   exit "${1:-0}"
 }
 
@@ -104,7 +130,7 @@ if ! $SCHEMA_ONLY; then
   # Collect *.json sorted by name (nullglob so a no-match glob yields nothing).
   shopt -s nullglob
   while IFS= read -r f; do reports+=("$f"); done < <(
-    for j in "$REPORTS_DIR"/*.json; do echo "$j"; done | sort
+    for j in "$REPORTS_DIR"/*.json; do echo "$j"; done | LC_ALL=C sort
   )
   shopt -u nullglob
   [[ ${#reports[@]} -gt 0 ]] || { echo "ERROR: no .json files in $REPORTS_DIR" >&2; exit 1; }
@@ -124,7 +150,8 @@ fi
 invoke_node_dist() {
   # $1 = args passed to `node dist`
   local dist_args="$1"
-  kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- sh -lc "cd '$WORKDIR' && node dist $dist_args"
+  # "${cexec[@]+...}" guards against an empty array under `set -u` on bash 3.2 (stock macOS).
+  kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- sh -lc "cd '$WORKDIR' && node dist $dist_args"
 }
 
 # Socket-mode psql into a CNPG rw service (peer auth as superuser, no password).
@@ -252,13 +279,13 @@ else
     expected="$(wc -c < "$r" | tr -d '[:space:]')"
     staged=false
     for ((attempt = 1; attempt <= max_stage_attempts; attempt++)); do
-      if ! base64 < "$r" | kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- \
+      if ! base64 < "$r" | kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
              sh -lc "base64 -d > '/tmp/$bn'"; then
         echo "   stage attempt $attempt/$max_stage_attempts failed (kubectl error)"
         continue
       fi
       # Verify the staged file is intact before importing (catches a truncated transfer).
-      if ! size="$(kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]}" -- \
+      if ! size="$(kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
                    sh -lc "wc -c < '/tmp/$bn'")"; then
         echo "   verify attempt $attempt/$max_stage_attempts failed (kubectl error)"
         continue

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -185,7 +185,7 @@ invoke_psql_svc() {
 }
 
 read -r -d '' SNAPSHOT_SQL <<'SQL' || true
-SELECT rd.name, rd.db_schema,
+SELECT rd.id AS definition_id, rd.name, rd.db_schema,
   max(rdv.version_number) AS latest,
   max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
 FROM report_definitions rd

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -185,7 +185,7 @@ invoke_psql_svc() {
 }
 
 read -r -d '' SNAPSHOT_SQL <<'SQL' || true
-SELECT rd.id AS definition_id, rd.name, rd.db_schema,
+SELECT rd.id, rd.name, rd.db_schema,
   max(rdv.version_number) AS latest,
   max(rdv.version_number) FILTER (WHERE rdv.status='published') AS latest_published
 FROM report_definitions rd

--- a/scripts/import-reports/import-reports-k8s.sh
+++ b/scripts/import-reports/import-reports-k8s.sh
@@ -312,6 +312,9 @@ else
       echo "   staged $bn is $size bytes, expected $expected (attempt $attempt/$max_stage_attempts); retrying"
     done
     if ! $staged; then
+      # Drop the partial/failed temp file before aborting so nothing is left in the pod.
+      kubectl exec -i -n "$NAMESPACE" "$POD" "${cexec[@]+"${cexec[@]}"}" -- \
+        sh -lc "rm -f '/tmp/$bn'" || true
       echo "ERROR: failed to stage $bn intact after $max_stage_attempts attempts (expected $expected bytes). Aborting." >&2
       exit 1
     fi


### PR DESCRIPTION
## What

Adds a matched pair of scripts under [`scripts/import-reports/`](scripts/import-reports/) to import Tamanu report definitions (and optionally a reporting schema) into a central server running on Kubernetes:

- `import-reports-k8s.ps1` — Windows (PowerShell)
- `import-reports-k8s.sh` — macOS/Linux (Bash), behaviour-for-behaviour equivalent
- `README.md` — prerequisites, PowerShell ↔ Bash option mapping, and examples

The PowerShell script was already in use for importing reporting schemas and reports to K8s Tamanu deployments; this brings it into the repo and adds the cross-platform Bash equivalent so the same workflow runs on any machine.

## Safety model

The `importReport` CLI has **no dry run**, so both scripts default to a read-only **PLAN**: resolve the pod, list what *would* be imported, and print the current report state. Nothing is written until you re-run with `-Apply` / `--apply`, which also prompts you to type the namespace back to confirm.

On apply: schema first (per `--schema-svc`, socket-mode `psql`, `SET ROLE`, single transaction), then each report staged as base64 with a byte-count verify and 3× retry against short writes, then imported via `node dist importReport`. A before/after snapshot is printed.

## Notes

- `*.sh` pinned to `eol=lf` in `.gitattributes` so the shell script never checks out with CRLF (which breaks bash).
- `bash -n` passes. shellcheck was not available locally — worth a CI pass if configured.

## Test plan

- [ ] Dry-run PLAN against a non-prod namespace (no `--apply`)
- [ ] Schema-only apply against a test service
- [ ] Full apply (schema + reports) against a test deployment, verify before/after snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)