### PR TITLE
feat(clinical): add clinical__measurement (vitals, labs, birth anthropometry)

### DIFF
--- a/models/clinical/clinical__measurement.md
+++ b/models/clinical/clinical__measurement.md
@@ -1,0 +1,64 @@
+{% docs clinical__measurement %}
+OMOP-lite MEASUREMENT domain: one row per clinical measurement, unioning vitals (Tamanu
+Vitals survey; the deprecated vitals table is now survey responses) and completed lab-test
+results. Numeric results populate value_as_number; categorical results keep
+value_source_value. Carries the Tamanu measurement as the source value with
+person/visit/provider foreign keys. measurement_concept_id (LOINC) and categorical result
+concepts are deferred to the future vocab__ layer. Deployment-specific measurements are
+added by per-deployment override.
+{% enddocs %}
+
+{% docs clinical__measurement__unit_source_value %}
+The unit of measure as recorded in Tamanu (from the lab test type). NULL for vitals, whose
+units are implicit in the vital type and not stored per answer.
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_id %}
+Unique identifier for the measurement; the OMOP measurement_id (the survey_response_answers
+id).
+{% enddocs %}
+
+{% docs clinical__measurement__visit_occurrence_id %}
+The encounter the vital was recorded on; the OMOP visit_occurrence_id. FK to
+clinical__visit_occurrence.
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_date %}
+Date component of the measurement datetime.
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_datetime %}
+Timestamp at which the measurement was taken — the Vitals survey response start time, or
+for labs the test completed time (falling back to the request's published/requested time).
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_type_source_value %}
+Provenance of the measurement: 'vitals survey' (Vitals survey answer), 'lab' (lab-test
+result), or 'birth data' (birth anthropometry from patient_birth_data). Deployment-specific
+sources carry their own values when added by override.
+{% enddocs %}
+
+{% docs clinical__measurement__value_as_number %}
+The measured value as a number, when the vital is numeric. NULL for categorical vitals
+(e.g. AVPU) — read value_source_value in that case.
+{% enddocs %}
+
+{% docs clinical__measurement__value_source_value %}
+The recorded value as entered in Tamanu, retained verbatim. Always populated (numeric or
+categorical); the canonical value for categorical vitals until a result concept is mapped.
+{% enddocs %}
+
+{% docs clinical__measurement__provider_id %}
+The user associated with the measurement — the vitals survey submitter, or the lab
+request's requesting clinician. FK to ref__provider.
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_source_value %}
+The Tamanu measurement type's code — the vital's program-data-element code (e.g. systolic
+blood pressure) or the lab test type's code.
+{% enddocs %}
+
+{% docs clinical__measurement__measurement_source_name %}
+The measurement type's readable name (program-data-element or lab-test-type name),
+denormalised alongside the code.
+{% enddocs %}

--- a/models/clinical/clinical__measurement.sql
+++ b/models/clinical/clinical__measurement.sql
@@ -1,0 +1,177 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__measurement -- OMOP-lite MEASUREMENT domain. One row per clinical measurement,
+-- unioning three standard sources: vitals via the Tamanu Vitals survey (BL-006), completed
+-- lab-test results (BL-007), and birth anthropometry unpivoted from patient_birth_data
+-- (BL-008, via int__patient_birth_measurements). Numeric results populate value_as_number;
+-- categorical results keep value_source_value. FK graph wired from the encounter where one
+-- exists (BL-002); *_concept_id (LOINC) deferred to the future vocab__ layer (BL-003).
+-- Sources only from bases/ + intermediate (D10). Deployment-specific measurements are added
+-- by per-deployment override (see spec). See spec for BL-001..BL-008.
+
+with survey_response_answers as (
+    select * from {{ ref('survey_response_answers') }}
+),
+
+survey_responses as (
+    select * from {{ ref('survey_responses') }}
+),
+
+surveys as (
+    select * from {{ ref('surveys') }}
+),
+
+program_data_elements as (
+    select * from {{ ref('program_data_elements') }}
+),
+
+encounters as (
+    select * from {{ ref('encounters') }}
+),
+
+lab_tests as (
+    select * from {{ ref('lab_tests') }}
+),
+
+lab_requests as (
+    select * from {{ ref('lab_requests') }}
+),
+
+lab_test_types as (
+    select * from {{ ref('lab_test_types') }}
+),
+
+patient_birth_measurements as (
+    select * from {{ ref('int__patient_birth_measurements') }}
+),
+
+-- every recorded answer to the core Vitals survey; numeric and categorical alike (BL-006)
+vitals_answers as (
+    select
+        sra.id,
+        trim(sra.body) as body,
+        sra.data_element_id,
+        sr.encounter_id,
+        sr.start_datetime,
+        sr.submitted_by_id
+    from survey_response_answers sra
+    join survey_responses sr on sr.id = sra.response_id
+    join surveys s on s.id = sr.survey_id and s.survey_type = 'vitals'
+    where sra.body is not null and trim(sra.body) != ''
+),
+
+-- vitals branch (BL-006). ids cast to varchar so the union with labs is type-safe
+vitals_measurements as (
+    select
+        va.id::varchar          as measurement_id,
+        e.patient_id::varchar   as person_id,
+        va.start_datetime::date as measurement_date,
+        va.start_datetime       as measurement_datetime,
+        'vitals survey'         as measurement_type_source_value,  -- provenance / union discriminator (BL-005)
+        case when va.body ~ '^-?[0-9]+(\.[0-9]+)?$' then va.body::numeric end as value_as_number,
+        va.body                 as value_source_value,
+        null::varchar           as unit_source_value,
+        va.submitted_by_id::varchar as provider_id,
+        va.encounter_id::varchar    as visit_occurrence_id,
+        pde.code as measurement_source_value,
+        pde.name as measurement_source_name
+    from vitals_answers va
+    join encounters e on e.id = va.encounter_id
+    left join program_data_elements pde on pde.id = va.data_element_id
+),
+
+-- lab branch: completed lab tests that have a result (BL-007)
+lab_measurements as (
+    select
+        lt.id::varchar        as measurement_id,
+        e.patient_id::varchar as person_id,
+        coalesce(lt.completed_datetime, lr.published_datetime, lr.requested_datetime)::date as measurement_date,
+        coalesce(lt.completed_datetime, lr.published_datetime, lr.requested_datetime)       as measurement_datetime,  -- completed, else published/requested (BL-004)
+        'lab'                 as measurement_type_source_value,
+        case when trim(lt.result) ~ '^-?[0-9]+(\.[0-9]+)?$' then trim(lt.result)::numeric end as value_as_number,
+        trim(lt.result)       as value_source_value,
+        ltt.unit              as unit_source_value,
+        lr.requested_by_id::varchar as provider_id,
+        lr.encounter_id::varchar    as visit_occurrence_id,
+        ltt.code as measurement_source_value,
+        ltt.name as measurement_source_name
+    from lab_tests lt
+    join lab_requests lr on lr.id = lt.lab_request_id
+    join encounters e on e.id = lr.encounter_id
+    left join lab_test_types ltt on ltt.id = lt.lab_test_type_id
+    where lt.result is not null and trim(lt.result) != ''
+      -- drop requests that never produced a valid result even if a stale value lingers (BL-007)
+      and lr.status not in ('deleted', 'sample-not-collected', 'entered-in-error')
+),
+
+-- birth anthropometry, unpivoted upstream by int__patient_birth_measurements (BL-008).
+-- Patient-level: no encounter, so provider_id and visit_occurrence_id are NULL
+birth_measurements as (
+    select
+        (bm.patient_id || '-birthdata-' || bm.measurement_source_value)::varchar as measurement_id,
+        bm.patient_id::varchar  as person_id,
+        bm.measurement_datetime::date as measurement_date,
+        bm.measurement_datetime as measurement_datetime,
+        'birth data'            as measurement_type_source_value,
+        case when trim(bm.value_source_value) ~ '^-?[0-9]+(\.[0-9]+)?$' then trim(bm.value_source_value)::numeric end as value_as_number,
+        bm.value_source_value   as value_source_value,
+        null::varchar           as unit_source_value,
+        null::varchar           as provider_id,
+        null::varchar           as visit_occurrence_id,
+        bm.measurement_source_value as measurement_source_value,
+        bm.measurement_source_name  as measurement_source_name
+    from patient_birth_measurements bm
+)
+
+-- columns listed explicitly per branch so reordering one branch can't silently mis-map
+select
+    measurement_id,
+    person_id,
+    measurement_date,
+    measurement_datetime,
+    measurement_type_source_value,
+    value_as_number,
+    value_source_value,
+    unit_source_value,
+    provider_id,
+    visit_occurrence_id,
+    measurement_source_value,
+    measurement_source_name
+from vitals_measurements
+
+union all
+
+select
+    measurement_id,
+    person_id,
+    measurement_date,
+    measurement_datetime,
+    measurement_type_source_value,
+    value_as_number,
+    value_source_value,
+    unit_source_value,
+    provider_id,
+    visit_occurrence_id,
+    measurement_source_value,
+    measurement_source_name
+from lab_measurements
+
+union all
+
+select
+    measurement_id,
+    person_id,
+    measurement_date,
+    measurement_datetime,
+    measurement_type_source_value,
+    value_as_number,
+    value_source_value,
+    unit_source_value,
+    provider_id,
+    visit_occurrence_id,
+    measurement_source_value,
+    measurement_source_name
+from birth_measurements

--- a/models/clinical/clinical__measurement.yml
+++ b/models/clinical/clinical__measurement.yml
@@ -1,0 +1,79 @@
+version: 2
+
+models:
+  - name: clinical__measurement
+    description: "{{ doc('clinical__measurement') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: measurement_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__measurement_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__measurement_measurement_id_not_null
+          - unique:
+              name: ac_002_clinical__measurement_measurement_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__patient_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_003_clinical__measurement_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: measurement_date
+        data_type: date
+        description: "{{ doc('clinical__measurement__measurement_date') }}"
+      - name: measurement_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__measurement__measurement_datetime') }}"
+        data_tests:
+          - not_null:
+              name: ac_007_clinical__measurement_measurement_datetime_not_null
+      - name: measurement_type_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__measurement_type_source_value') }}"
+      - name: value_as_number
+        data_type: numeric
+        description: "{{ doc('clinical__measurement__value_as_number') }}"
+      - name: value_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__value_source_value') }}"
+        data_tests:
+          - not_null:
+              name: ac_006_clinical__measurement_value_source_value_not_null
+      - name: unit_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__unit_source_value') }}"
+      - name: provider_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__provider_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_005_clinical__measurement_provider_id_in_ref__provider
+              arguments:
+                to: ref('ref__provider')
+                field: provider_id
+      - name: visit_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__visit_occurrence_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_004_clinical__measurement_visit_occurrence_id_in_clinical__visit_occurrence
+              arguments:
+                to: ref('clinical__visit_occurrence')
+                field: visit_occurrence_id
+      - name: measurement_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__measurement_source_value') }}"
+      - name: measurement_source_name
+        data_type: character varying(255)
+        description: "{{ doc('clinical__measurement__measurement_source_name') }}"

--- a/models/intermediate/standard/int__patient_birth_measurements.sql
+++ b/models/intermediate/standard/int__patient_birth_measurements.sql
@@ -1,0 +1,50 @@
+-- int__patient_birth_measurements -- unpivots the wide patient_birth_data into one row per
+-- recorded birth measurement (tall shape), for the birth-data branch of clinical__measurement.
+-- Inner-joins patients (which filters deleted/test/merged patients and supplies the birth
+-- date), so every row is a valid patient; birth measurements are patient-level (no encounter).
+-- Values are kept as text here; the numeric cast happens in clinical__measurement.
+
+with patient_birth_data as (
+    select * from {{ ref('patient_birth_data') }}
+),
+
+patients as (
+    select * from {{ ref('patients') }}
+),
+
+birth as (
+    select
+        pbd.patient_id,
+        pbd.birth_weight,
+        pbd.birth_length,
+        pbd.apgar_score_one_minute,
+        pbd.apgar_score_five_minutes,
+        pbd.apgar_score_ten_minutes,
+        pbd.gestational_age_estimate,
+        -- a birth measurement is taken at birth; fall back to the registration date
+        coalesce(
+            (p.date_of_birth + pbd.birth_time)::timestamp,
+            p.date_of_birth::timestamp,
+            pbd.registration_date::timestamp
+        ) as measurement_datetime
+    from patient_birth_data pbd
+    join patients p on p.id = pbd.patient_id
+)
+
+-- one row per recorded measure; blanks are dropped
+select
+    b.patient_id,
+    m.measurement_source_value,
+    m.measurement_source_name,
+    m.value_source_value,
+    b.measurement_datetime
+from birth b
+cross join lateral (values
+    ('birth_weight',             'Birth weight',             b.birth_weight::varchar),
+    ('birth_length',             'Birth length',             b.birth_length::varchar),
+    ('apgar_score_one_minute',   'APGAR score (1 minute)',   b.apgar_score_one_minute::varchar),
+    ('apgar_score_five_minutes', 'APGAR score (5 minutes)',  b.apgar_score_five_minutes::varchar),
+    ('apgar_score_ten_minutes',  'APGAR score (10 minutes)', b.apgar_score_ten_minutes::varchar),
+    ('gestational_age_estimate', 'Gestational age estimate', b.gestational_age_estimate::varchar)
+) as m (measurement_source_value, measurement_source_name, value_source_value)
+where m.value_source_value is not null and trim(m.value_source_value) != ''

--- a/specs/dbt-model/clinical__measurement.md
+++ b/specs/dbt-model/clinical__measurement.md
@@ -1,0 +1,190 @@
+# dbt Model Spec: `clinical__measurement` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__measurement` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `implemented` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-07-04 |
+| **Last updated** | 2026-07-09 |
+
+The OMOP-lite `MEASUREMENT` domain — one row per clinical measurement (numeric or
+categorical), unioning three standard sources: **vitals** (blood pressure, weight, glucose,
+AVPU, …) recorded via the Tamanu **Vitals survey**, **lab-test results**, and **birth
+anthropometry** (birth weight/length, APGAR, gestational age) from `patient_birth_data`.
+Deployment-specific measurements are a per-deployment extension. Feeds the NCD
+"under control" indicators, which key on recent BP / glucose readings. See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping, `surveys`/`vocab__`),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One row per recorded answer to a Vitals-survey response —
+i.e. one recorded vital sign (systolic/diastolic BP, weight, height, blood glucose, heart
+rate, SpO2, AVPU, …), in OMOP `MEASUREMENT` shape: native UUID PK, the value (numeric where
+the vital is quantitative, else the categorical source value), the Tamanu vital retained as
+the source value, the measurement datetime, and the person / visit / provider foreign keys.
+Vitals are **not always numeric** — categorical vitals (e.g. AVPU, urine dipstick) are
+measurements too, carried via `value_source_value` with `value_as_number` NULL.
+
+**Clinical context.** Three sources, unioned:
+- **Vitals** — Tamanu's dedicated `vitals` table is **deprecated**; vitals are now responses
+  to the core **Vitals survey** (`surveys.survey_type = 'vitals'`), one
+  `survey_response_answer` per vital, typed by the answer's `program_data_element`.
+- **Labs** — a completed `lab_tests` row carries a `result`, typed by its `lab_test_type`
+  (code, name, unit), under a `lab_request` tied to an encounter.
+- **Birth anthropometry** — `patient_birth_data` holds birth weight/length, APGAR scores,
+  and gestational age in *wide* form (one row per patient). `int__patient_birth_measurements`
+  unpivots it to one row per measure; these are patient-level (no encounter).
+
+OMOP analytics expect all three as `MEASUREMENT` rows keyed by `measurement_id`; lab results
+and birth anthropometry are `MEASUREMENT`s in OMOP, so they belong here, not in a separate
+model.
+
+**Who reads it.** `derived__cohort_*` and `metric__` NCD indicators — most importantly the
+hypertension / diabetes "under control" family, which reads the most recent BP / glucose
+measurement per patient (see the `hypertension_controlled` worked example in D5); and
+`dataset__` vitals line-lists.
+
+**Standard model, deployment extension.** `tamanu-source-dbt` is the *standard* model: it
+covers the standard Tamanu **Vitals survey**, which every deployment shares. A deployment
+that records additional measurements (deployment-specific vitals, or measurements captured
+in a program/registry survey) **extends `clinical__measurement` in its own
+`tamanu-dbt-<deployment>` project** — the per-deployment override mechanism (D2) — to union
+those in. This is by design, not an omission; the standard model stays universal.
+
+## Grain
+
+**One row per:** recorded Vitals-survey answer (PK `survey_response_answers.id`),
+completed lab test with a result (PK `lab_tests.id`), or recorded birth measure (synthetic
+PK `<patient_id>-birthdata-<measure>`), unioned. Only rows with a recorded (non-blank) value
+are kept (BL-006, BL-007, BL-008); numeric values populate `value_as_number`, categorical
+values carry `value_source_value` with `value_as_number` NULL. The three id spaces are
+disjoint, so `measurement_id` is unique across the union; all joins are many-to-one, so grain
+is preserved.
+
+## Output schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `measurement_id` | uuid | `survey_response_answers.id` (vital), `lab_tests.id` (lab), or synthetic `<patient_id>-birthdata-<measure>` (birth). PK (D1) |
+| `person_id` | uuid | `encounters.patient_id` (vitals/labs, via `encounter_id`) or `patient_id` directly (birth). FK to `clinical__person.person_id` |
+| `measurement_date` | date | Date component of the measurement datetime |
+| `measurement_datetime` | timestamp | Vitals: response `start_time`. Labs: `lab_tests.completed_datetime` (→ published/requested). Birth: birth datetime (→ registration date) |
+| `measurement_type_source_value` | text | `'vitals survey'`, `'lab'`, or `'birth data'` — provenance / union discriminator |
+| `value_as_number` | numeric | The value cast to numeric when numeric; **NULL for categorical results** (BL-003, BL-006, BL-007) |
+| `value_source_value` | text | The recorded value, retained verbatim. Always populated — the canonical value for categorical results |
+| `unit_source_value` | text | Unit of measure. Labs: `lab_test_types.unit`. NULL for vitals (units implicit, not stored per answer) |
+| `provider_id` | uuid | Vitals: response submitter. Labs: requesting clinician. Birth: NULL (no user recorded). FK to `ref__provider.provider_id` |
+| `visit_occurrence_id` | uuid | The source's `encounter_id`; **NULL for birth measurements** (patient-level). FK to `clinical__visit_occurrence.visit_occurrence_id` |
+| `measurement_source_value` | text | The measurement type's code — `program_data_elements.code` (vital) or `lab_test_types.code` (lab) |
+| `measurement_source_name` | text | The measurement type's name, denormalised for readability |
+
+`measurement_concept_id` / `measurement_source_concept_id` (OMOP standard LOINC),
+`value_as_concept_id` (standard concept for a categorical result), and `unit_concept_id`
+are **not** emitted — see BL-003 and OQ-1.
+
+## Business logic
+
+- **BL-001:** The model is the `union all` of three branches — vitals (BL-006), labs
+  (BL-007), and birth anthropometry (BL-008) — sourced from `{{ ref('survey_response_answers') }}`,
+  `{{ ref('survey_responses') }}`, `{{ ref('surveys') }}`, `{{ ref('program_data_elements') }}`,
+  `{{ ref('lab_tests') }}`, `{{ ref('lab_requests') }}`, `{{ ref('lab_test_types') }}`,
+  `{{ ref('int__patient_birth_measurements') }}`, and `{{ ref('encounters') }}` only (D10) —
+  never `public.*`. Soft-delete / test-patient filtering is inherited from the base models;
+  the branch PKs (`survey_response_answers.id`, `lab_tests.id`, and the synthetic
+  `<patient_id>-birthdata-<measure>`) occupy disjoint id spaces so `measurement_id` is unique,
+  and the joins are many-to-one, so grain is preserved.
+- **BL-002:** OMOP foreign keys are wired from the source row's encounter: `person_id` is the
+  encounter's `patient_id`, `visit_occurrence_id` is the `encounter_id` (the vitals response's
+  or the lab request's), and `provider_id` is the vitals submitter / lab requester. Ids are
+  cast to `varchar` for a type-safe union. All resolve to `clinical__person`,
+  `clinical__visit_occurrence`, and `ref__provider`.
+- **BL-003:** `value_as_number` is the value cast to numeric **only when it is numeric** (a
+  signed-decimal pattern); for categorical results it is NULL. `value_source_value` always
+  keeps the recorded value — the canonical value for categorical results (e.g. AVPU) and the
+  raw value for numeric ones. `measurement_source_value`/`_name` are the measurement type's
+  code/name (vital data element or lab test type); `unit_source_value` is the lab test's unit
+  (NULL for vitals). `measurement_concept_id` (LOINC) and `value_as_concept_id` (a standard
+  concept for a categorical result) are **not** emitted: mapping Tamanu data elements / lab
+  test types / result options to standard concepts needs the `vocab__` layer (D2, and the
+  `lookup__vital_type` seed noted there), not inline logic. Source code/name/value are
+  retained so the standard concepts layer on later (OQ-1), never replacing local values (D1).
+- **BL-004:** `measurement_datetime` is when the measurement was taken — the vitals response
+  `start_time`, or for labs `lab_tests.completed_datetime` (falling back to the request's
+  `published`/`requested` datetime). `measurement_date` is its date component.
+- **BL-005:** `measurement_type_source_value` records provenance and is the union
+  discriminator: `'vitals survey'`, `'lab'`, or `'birth data'`. Deployment extensions
+  carry their own values.
+- **BL-006 (vitals branch):** Every Vitals-survey (`survey_type = 'vitals'`) answer with a
+  recorded (non-blank) `body` is included — **numeric and categorical alike**, since a
+  categorical vital (e.g. AVPU) is still a measurement in OMOP (value in
+  `value_source_value`). Only blank/unanswered questions are excluded. The
+  measurement/observation split is by **survey**, not value type: the Vitals survey feeds
+  `clinical__measurement`; qualitative results from *other* surveys (social history,
+  program-survey flags) feed `clinical__observation`.
+- **BL-007 (lab branch):** Every `lab_tests` row with a recorded (non-blank) `result` is
+  included, joined through `lab_requests` to its encounter and `lab_test_types` for the test
+  code/name/unit. Tests without a result (pending/incomplete) are excluded — a measurement
+  exists only once a result is recorded. Requests in a non-result status —
+  `deleted`, `sample-not-collected`, `entered-in-error` — are also excluded even if a stale
+  `result` value lingers, so voided work never surfaces as a measurement. Numeric results
+  populate `value_as_number`; qualitative results (e.g. "positive"/"negative") carry
+  `value_source_value`.
+- **BL-008 (birth-data branch):** Birth anthropometry (birth weight, birth length, APGAR at
+  1/5/10 min, gestational age estimate) is unpivoted from the wide `patient_birth_data` by
+  `int__patient_birth_measurements` — one row per recorded measure, blanks dropped. These are
+  **patient-level**: `person_id` is the `patient_id` directly (the int model inner-joins
+  `patients`, so only valid non-test/non-merged patients appear), `visit_occurrence_id` and
+  `provider_id` are NULL, and `measurement_datetime` is the birth datetime
+  (`patients.date_of_birth` + `time_of_birth`, falling back to the registration date). The
+  `measurement_id` is synthesised as `<patient_id>-birthdata-<measure>` (unique — one birth
+  record per patient). Unpivot logic lives in the int model to keep this model a clean union.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `measurement_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `measurement_id` is `unique` | grain | dbt `unique` |
+| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-002 | dbt `relationships` |
+| AC-004 | Every `visit_occurrence_id` exists in `clinical__visit_occurrence.visit_occurrence_id` | BL-002 | dbt `relationships` |
+| AC-005 | Every non-null `provider_id` exists in `ref__provider.provider_id` | BL-002 | dbt `relationships` |
+| AC-006 | `value_source_value` is `not_null` (every measurement has a recorded value; `value_as_number` is nullable for categorical results) | BL-006, BL-007 | dbt `not_null` |
+| AC-007 | `measurement_datetime` is `not_null` | BL-004 | dbt `not_null` |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` / `derived__` artefacts get a `metric_definitions.csv` row.
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `survey_response_answers` | `bases/` | The measurement value (`body`) and its data-element FK |
+| `survey_responses` | `bases/` | Datetime, encounter (person + visit) anchor, submitter |
+| `surveys` | `bases/` | Restrict the vitals branch to `survey_type = 'vitals'` |
+| `program_data_elements` | `bases/` | The vital type (code + name) |
+| `lab_tests` | `bases/` | Lab result value, completed datetime, test-type FK (lab branch) |
+| `lab_requests` | `bases/` | Lab encounter anchor, requester, request datetimes |
+| `lab_test_types` | `bases/` | Lab test code, name, and unit |
+| `int__patient_birth_measurements` | `intermediate/` | Unpivots `patient_birth_data` (+ `patients`) into tall birth measurements (birth branch) |
+| `encounters` | `bases/` | Person (`patient_id`) via the source `encounter_id` (vitals/labs) |
+| `clinical__person` | `clinical/` | `person_id` FK target (AC-003) |
+| `clinical__visit_occurrence` | `clinical/` | `visit_occurrence_id` FK target (AC-004) |
+| `ref__provider` | `ref/` | `provider_id` FK target (AC-005) |
+
+## Open questions
+
+- **OQ-1:** `measurement_concept_id` (LOINC), `value_as_concept_id` (a standard concept for
+  categorical results such as AVPU levels), and `unit_concept_id` await a measurement-type
+  map (`lookup__vital_type`, D2) / the `vocab__` layer. `unit_source_value` is populated for
+  labs; vitals units remain implicit in the Tamanu vital data element (not stored per answer).


### PR DESCRIPTION
## Summary

Adds the OMOP-lite `MEASUREMENT` domain: one row per clinical measurement, unioning three standard sources —

- **Vitals** — every recorded (numeric or categorical) answer to the Tamanu Vitals survey (`surveys.survey_type = 'vitals'`). Categorical vitals (e.g. AVPU) are retained via `value_source_value` with `value_as_number` NULL, not dropped.
- **Labs** — completed `lab_tests` rows with a result, excluding voided requests (`deleted` / `sample-not-collected` / `entered-in-error`) even if a stale `result` lingers.
- **Birth anthropometry** — birth weight/length, APGAR (1/5/10 min), gestational age, unpivoted from wide `patient_birth_data` by a new intermediate model, `int__patient_birth_measurements`. Patient-level (no encounter): `visit_occurrence_id`/`provider_id` are NULL.

`tamanu-source-dbt` is the standard model; a deployment recording additional measurements (deployment-specific vitals or program/registry-survey data) extends `clinical__measurement` in its own `tamanu-dbt-<deployment>` project.

Ships with:
- `models/clinical/clinical__measurement.{sql,yml,md}`
- `models/intermediate/standard/int__patient_birth_measurements.sql`
- `specs/dbt-model/clinical__measurement.md` — BL-001..008 anchored in SQL, AC-001..007 tested

## Why

Feeds the NCD hypertension/diabetes "under control" indicators, which key on the most recent BP/glucose measurement per patient, plus `dataset__` vitals line-lists.

## Base branch

Based on `clinical-and-ref-models` rather than `main`: `main` doesn't yet have `ref__provider`, `clinical__person`, or `clinical__visit_occurrence` (measurement's FK targets), which live in this stacked integration branch alongside the earlier `ref__care_site`/`clinical__visit_detail`/`clinical__condition_occurrence` work. This keeps the diff to just the 5 files above.

## Test plan

- [x] `dbt parse` clean
- [x] `dbt test --select clinical__measurement` — 7/7 passing (AC-001..007)
- [x] Spec-anchor check (`.maui/scripts/check_spec_anchors.py`) — all BL-001..008 resolve to code anchors
- [x] Manually verified the lab-status filter values (`deleted`, `sample-not-collected`, `entered-in-error`) against the existing standard reporting schema's `lab_requests.status` case mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)