### PR TITLE
feat(clinical): add clinical__drug_exposure (prescriptions, vaccinations, dispenses)

### DIFF
--- a/models/clinical/clinical__drug_exposure.md
+++ b/models/clinical/clinical__drug_exposure.md
@@ -1,0 +1,75 @@
+{% docs clinical__drug_exposure %}
+OMOP-lite DRUG_EXPOSURE domain: one row per drug exposure, unioning medication prescriptions
+(the clinical intent to treat), vaccine administrations (status GIVEN only), and pharmacy
+dispenses (the physical hand-over of stock). Carries the Tamanu drug/vaccine as the source
+value with person/visit/provider foreign keys. drug_concept_id (RxNorm/CVX) is deferred to
+the future vocab__ layer. Deployment-specific drug sources are added by per-deployment
+override.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_exposure_id %}
+Unique identifier for the drug exposure; the OMOP drug_exposure_id (the prescriptions,
+administered_vaccines, or medication_dispenses id, depending on branch).
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_exposure_start_date %}
+Date component of the drug exposure start datetime.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_exposure_start_datetime %}
+Timestamp at which the exposure began — the prescription's start date (falling back to its
+date), the vaccination's date, or the dispense's dispensed-at time.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_exposure_end_datetime %}
+Timestamp at which the exposure ended — the prescription's end date. Vaccinations and
+dispenses are point events, so their end equals their start.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_exposure_type_source_value %}
+Provenance of the exposure: 'prescription' (medication prescribed), 'vaccination' (vaccine
+given), or 'dispense' (medication physically dispensed). Deployment-specific sources carry
+their own values when added by override.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__quantity %}
+Quantity associated with the exposure — the prescription's quantity to dispense, or the
+dispense's dispensed quantity. NULL for vaccinations.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__refills %}
+Number of repeats authorised on the prescription. NULL for vaccination and dispense rows.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__route_source_value %}
+Administration route as recorded in Tamanu — the prescription's route, the vaccination's
+injection site, or (for a dispense) the originating prescription's route.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__stop_reason %}
+Reason the prescription was discontinued, when it was. NULL for vaccination and dispense
+rows, and for prescriptions that were not discontinued.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__provider_id %}
+The user associated with the exposure — the prescriber, or the dispensing pharmacist. For
+vaccinations, the user who recorded the administration (recorded_by_id) when captured, else
+the free-text given_by name (which may not reference a Tamanu user, so isn't FK-checked for
+this branch). FK to ref__provider for prescription and dispense rows.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__visit_occurrence_id %}
+The encounter the exposure was recorded on; the OMOP visit_occurrence_id. FK to
+clinical__visit_occurrence.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_source_value %}
+The Tamanu drug/vaccine code — reference_data.code for prescriptions and dispenses, or (for
+vaccinations) the code resolved via the scheduled vaccine when the dose is scheduled; NULL
+for ad hoc/catch-up doses with no schedule.
+{% enddocs %}
+
+{% docs clinical__drug_exposure__drug_source_name %}
+The drug/vaccine's readable name, denormalised alongside the code. Always populated for
+vaccinations (the row's own vaccine_name) regardless of whether drug_source_value resolved.
+{% enddocs %}

--- a/models/clinical/clinical__drug_exposure.sql
+++ b/models/clinical/clinical__drug_exposure.sql
@@ -1,0 +1,183 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__drug_exposure -- OMOP-lite DRUG_EXPOSURE domain. One row per drug exposure,
+-- unioning three standard sources: medication prescriptions (BL-006), vaccine
+-- administrations with status = 'GIVEN' (BL-007), and pharmacy dispenses (BL-008). Drug
+-- identity retained as source value; FK graph wired from the encounter (BL-002);
+-- *_concept_id (RxNorm/CVX) deferred to the future vocab__ layer (BL-003). Sources only
+-- from bases/ (D10). Deployment-specific drug sources are added by per-deployment override
+-- (see spec). See spec for BL-001..BL-008.
+
+with prescriptions as (
+    select * from {{ ref('prescriptions') }}
+),
+
+encounter_prescriptions as (
+    select * from {{ ref('encounter_prescriptions') }}
+),
+
+reference_data as (
+    select * from {{ ref('reference_data') }}
+),
+
+vaccine_administrations as (
+    select * from {{ ref('vaccine_administrations') }}
+),
+
+vaccine_schedules as (
+    select * from {{ ref('vaccine_schedules') }}
+),
+
+medication_dispenses as (
+    select * from {{ ref('medication_dispenses') }}
+),
+
+pharmacy_order_prescriptions as (
+    select * from {{ ref('pharmacy_order_prescriptions') }}
+),
+
+pharmacy_orders as (
+    select * from {{ ref('pharmacy_orders') }}
+),
+
+encounters as (
+    select * from {{ ref('encounters') }}
+),
+
+-- prescription branch: every prescription, joined to its encounter and drug (BL-006)
+prescription_exposures as (
+    select
+        p.id::varchar as drug_exposure_id,
+        e.patient_id::varchar as person_id,
+        coalesce(p.start_datetime, p.datetime)::date as drug_exposure_start_date,
+        coalesce(p.start_datetime, p.datetime) as drug_exposure_start_datetime,
+        p.end_datetime as drug_exposure_end_datetime,
+        'prescription' as drug_exposure_type_source_value,  -- provenance / union discriminator (BL-005)
+        p.quantity::numeric as quantity,
+        p.repeats as refills,
+        p.route as route_source_value,
+        -- exposure still occurred even when discontinued; keep the row, record why it stopped (BL-006)
+        case when p.is_discontinued then p.discontinuing_reason end as stop_reason,
+        p.prescriber_id::varchar as provider_id,
+        ep.encounter_id::varchar as visit_occurrence_id,
+        rd.code as drug_source_value,
+        rd.name as drug_source_name
+    from prescriptions p
+    join encounter_prescriptions ep on ep.prescription_id = p.id
+    join encounters e on e.id = ep.encounter_id
+    left join reference_data rd on rd.id = p.medication_id
+),
+
+-- vaccination branch: GIVEN administrations only (BL-007). RECORDED_IN_ERROR (a deleted
+-- GIVEN) and HISTORICAL (a hidden shadow of a separate GIVEN row) are excluded so a real
+-- exposure isn't double-counted; NOT_GIVEN belongs in clinical__observation, not here
+vaccination_exposures as (
+    select
+        av.id::varchar as drug_exposure_id,
+        e.patient_id::varchar as person_id,
+        av.datetime::date as drug_exposure_start_date,
+        av.datetime as drug_exposure_start_datetime,
+        av.datetime as drug_exposure_end_datetime,  -- point event: end equals start (BL-004)
+        'vaccination' as drug_exposure_type_source_value,
+        null::numeric as quantity,
+        null::integer as refills,
+        av.injection_site as route_source_value,
+        null::varchar as stop_reason,
+        -- recorded_by_id (a real user FK) preferred; given_by is free text (may name a
+        -- non-Tamanu-user) and is only a fallback when no recording user was captured.
+        -- provider_id's FK test is scoped off vaccination rows for this reason (BL-002)
+        coalesce(av.recorded_by_id, av.given_by)::varchar as provider_id,
+        av.encounter_id::varchar as visit_occurrence_id,
+        rd.code as drug_source_value,
+        av.vaccine_name as drug_source_name
+    from vaccine_administrations av
+    join encounters e on e.id = av.encounter_id
+    left join vaccine_schedules vs on vs.id = av.scheduled_vaccine_id
+    left join reference_data rd on rd.id = vs.vaccine_id
+    where av.status = 'GIVEN'
+),
+
+-- dispense branch: physical hand-over of stock; drug identity comes from the originating
+-- prescription, since a dispense carries no medication_id of its own (BL-008)
+dispense_exposures as (
+    select
+        md.id::varchar as drug_exposure_id,
+        e.patient_id::varchar as person_id,
+        md.dispensed_at::date as drug_exposure_start_date,
+        md.dispensed_at as drug_exposure_start_datetime,
+        md.dispensed_at as drug_exposure_end_datetime,  -- point event: end equals start (BL-004)
+        'dispense' as drug_exposure_type_source_value,
+        md.quantity::numeric as quantity,
+        null::integer as refills,
+        p.route as route_source_value,
+        null::varchar as stop_reason,
+        md.dispensed_by_user_id::varchar as provider_id,
+        po.encounter_id::varchar as visit_occurrence_id,
+        rd.code as drug_source_value,
+        rd.name as drug_source_name
+    from medication_dispenses md
+    join pharmacy_order_prescriptions pop on pop.id = md.pharmacy_order_prescription_id
+    join pharmacy_orders po on po.id = pop.pharmacy_order_id
+    join encounters e on e.id = po.encounter_id
+    join prescriptions p on p.id = pop.prescription_id
+    left join reference_data rd on rd.id = p.medication_id
+)
+
+-- columns listed explicitly per branch so reordering one branch can't silently mis-map
+select
+    drug_exposure_id,
+    person_id,
+    drug_exposure_start_date,
+    drug_exposure_start_datetime,
+    drug_exposure_end_datetime,
+    drug_exposure_type_source_value,
+    quantity,
+    refills,
+    route_source_value,
+    stop_reason,
+    provider_id,
+    visit_occurrence_id,
+    drug_source_value,
+    drug_source_name
+from prescription_exposures
+
+union all
+
+select
+    drug_exposure_id,
+    person_id,
+    drug_exposure_start_date,
+    drug_exposure_start_datetime,
+    drug_exposure_end_datetime,
+    drug_exposure_type_source_value,
+    quantity,
+    refills,
+    route_source_value,
+    stop_reason,
+    provider_id,
+    visit_occurrence_id,
+    drug_source_value,
+    drug_source_name
+from vaccination_exposures
+
+union all
+
+select
+    drug_exposure_id,
+    person_id,
+    drug_exposure_start_date,
+    drug_exposure_start_datetime,
+    drug_exposure_end_datetime,
+    drug_exposure_type_source_value,
+    quantity,
+    refills,
+    route_source_value,
+    stop_reason,
+    provider_id,
+    visit_occurrence_id,
+    drug_source_value,
+    drug_source_name
+from dispense_exposures

--- a/models/clinical/clinical__drug_exposure.yml
+++ b/models/clinical/clinical__drug_exposure.yml
@@ -1,0 +1,94 @@
+version: 2
+
+models:
+  - name: clinical__drug_exposure
+    description: "{{ doc('clinical__drug_exposure') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: drug_exposure_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__drug_exposure_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__drug_exposure_drug_exposure_id_not_null
+          - unique:
+              name: ac_002_clinical__drug_exposure_drug_exposure_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__patient_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_003_clinical__drug_exposure_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: drug_exposure_start_date
+        data_type: date
+        description: "{{ doc('clinical__drug_exposure__drug_exposure_start_date') }}"
+      - name: drug_exposure_start_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__drug_exposure__drug_exposure_start_datetime') }}"
+        data_tests:
+          - not_null:
+              name: ac_006_clinical__drug_exposure_drug_exposure_start_datetime_not_null
+      - name: drug_exposure_end_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__drug_exposure__drug_exposure_end_datetime') }}"
+      - name: drug_exposure_type_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__drug_exposure_type_source_value') }}"
+        data_tests:
+          - accepted_values:
+              name: ac_007_clinical__drug_exposure_drug_exposure_type_source_value_accepted
+              arguments:
+                values:
+                  - prescription
+                  - vaccination
+                  - dispense
+      - name: quantity
+        data_type: numeric
+        description: "{{ doc('clinical__drug_exposure__quantity') }}"
+      - name: refills
+        data_type: integer
+        description: "{{ doc('clinical__drug_exposure__refills') }}"
+      - name: route_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__route_source_value') }}"
+      - name: stop_reason
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__stop_reason') }}"
+      - name: provider_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__provider_id') }}"
+        data_tests:
+          - dbt_utils.relationships_where:
+              name: ac_005_clinical__drug_exposure_provider_id_in_ref__provider
+              arguments:
+                to: ref('ref__provider')
+                field: provider_id
+                from_condition: "drug_exposure_type_source_value != 'vaccination'"
+      - name: visit_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__visit_occurrence_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_004_clinical__drug_exposure_visit_occurrence_id_in_clinical__visit_occurrence
+              arguments:
+                to: ref('clinical__visit_occurrence')
+                field: visit_occurrence_id
+      - name: drug_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__drug_source_value') }}"
+      - name: drug_source_name
+        data_type: character varying(255)
+        description: "{{ doc('clinical__drug_exposure__drug_source_name') }}"
+        data_tests:
+          - not_null:
+              name: ac_008_clinical__drug_exposure_drug_source_name_not_null

--- a/specs/dbt-model/clinical__drug_exposure.md
+++ b/specs/dbt-model/clinical__drug_exposure.md
@@ -1,0 +1,189 @@
+# dbt Model Spec: `clinical__drug_exposure` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__drug_exposure` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `draft` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-07-09 |
+| **Last updated** | 2026-07-09 |
+
+The OMOP-lite `DRUG_EXPOSURE` domain — one row per drug exposure, unioning three standard
+sources: **medication prescriptions** (the clinical intent to treat), **vaccine
+administrations** (`status = 'GIVEN'`), and **pharmacy dispenses** (the physical hand-over of
+stock). Each row carries the Tamanu drug/vaccine as the source value with person / visit /
+provider foreign keys. Deployment-specific drug sources are a per-deployment extension. Feeds
+the NCD "on treatment" indicators (e.g. patients on antihypertensives / metformin) and
+immunisation-coverage metrics. See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping, `vocab__`),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One row per drug exposure in OMOP `DRUG_EXPOSURE` shape:
+native UUID PK, the exposure start/end datetimes, the Tamanu drug/vaccine retained as the
+source value, and the person / visit / provider foreign keys. A "drug exposure" spans the
+whole medication lifecycle — a clinician *prescribing* a drug, a *vaccine being given*, and a
+pharmacy *dispensing* stock are all exposures in OMOP, distinguished by
+`drug_exposure_type_source_value` so a consumer can pick the evidence level it needs.
+
+**Clinical context.** Three sources, unioned:
+- **Prescriptions** — a `prescriptions` row is the clinical intent to treat: drug
+  (`medication_id` → `reference_data`, `type = 'drug'`), prescriber, dose/route/frequency,
+  start/end dates, and a discontinuation trail. It has no encounter of its own — the
+  `encounter_prescriptions` link table ties it to an encounter.
+- **Vaccinations** — a `vaccine_administrations` row records a vaccine event against an
+  encounter, carrying the denormalised `vaccine_name` and a `status`; only `GIVEN` rows are
+  actual exposures. `scheduled_vaccine_id` (nullable — ad hoc/catch-up doses aren't scheduled)
+  resolves through `vaccine_schedules` to `reference_data` (`type = 'drug'`, the same
+  namespace as prescriptions) for a coded `drug_source_value` when available.
+- **Dispenses** — a `medication_dispenses` row is the physical supply event, reached through
+  the pharmacy chain (`pharmacy_order_prescriptions` → `pharmacy_orders` → encounter, and →
+  the originating `prescription` for the drug identity). It carries only quantity/when/by-whom.
+
+Prescriptions are the universal signal (every deployment prescribes); the pharmacy/dispensing
+module is newer and not present in every deployment. All three are `DRUG_EXPOSURE` rows in
+OMOP, so they belong in one model, type-discriminated, not in separate models.
+
+**Who reads it.** `derived__cohort_*` and `metric__` NCD indicators — most importantly the
+hypertension / diabetes "on treatment" family, which asks whether a patient has a current
+prescription for a relevant drug class; and immunisation-coverage `dataset__` line-lists.
+
+**Standard model, deployment extension.** `tamanu-source-dbt` is the *standard* model: it
+covers the standard Tamanu prescription, vaccine, and dispense tables that every deployment
+shares. A deployment that records additional drug sources **extends `clinical__drug_exposure`
+in its own `tamanu-dbt-<deployment>` project** — the per-deployment override mechanism (D2) —
+to union those in. This is by design, not an omission; the standard model stays universal.
+
+## Grain
+
+**One row per:** medication prescription (PK `prescriptions.id`), vaccine administration with
+`status = 'GIVEN'` (PK `administered_vaccines.id`), or pharmacy dispense (PK
+`medication_dispenses.id`), unioned. The three id spaces are disjoint, so `drug_exposure_id`
+is unique across the union; all joins are many-to-one, so grain is preserved.
+
+## Output schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `drug_exposure_id` | uuid | `prescriptions.id` (prescription), `administered_vaccines.id` (vaccination), or `medication_dispenses.id` (dispense). PK (D1) |
+| `person_id` | uuid | `encounters.patient_id` via the source's encounter. FK to `clinical__person.person_id` |
+| `drug_exposure_start_date` | date | Date component of the start datetime |
+| `drug_exposure_start_datetime` | timestamp | Prescription: `start_date` (→ `date`). Vaccination: `date`. Dispense: `dispensed_at` |
+| `drug_exposure_end_datetime` | timestamp | Prescription: `end_date`. Vaccination / dispense: the start datetime (point events) |
+| `drug_exposure_type_source_value` | text | `'prescription'`, `'vaccination'`, or `'dispense'` — provenance / union discriminator |
+| `quantity` | numeric | Prescription: `quantity`. Dispense: `quantity`. Vaccination: NULL |
+| `refills` | integer | Prescription: `repeats`. NULL for vaccination / dispense |
+| `route_source_value` | text | Prescription: `route`. Vaccination: `injection_site`. Dispense: the prescription's `route` |
+| `stop_reason` | text | Prescription: `discontinuing_reason` (when discontinued). NULL for vaccination / dispense |
+| `provider_id` | uuid or text | Prescription: `prescriber_id`. Vaccination: `coalesce(recorded_by_id, given_by)` — the recording user when captured, else the free-text administerer name. Dispense: `dispensed_by_user_id`. FK to `ref__provider.provider_id` for prescription/dispense only (AC-005) |
+| `visit_occurrence_id` | uuid | The source's `encounter_id`. FK to `clinical__visit_occurrence.visit_occurrence_id` |
+| `drug_source_value` | text | Prescription / dispense: `reference_data.code`. Vaccination: `reference_data.code` via `scheduled_vaccine_id` when the dose is scheduled, else NULL (ad hoc/catch-up) |
+| `drug_source_name` | text | Prescription / dispense: `reference_data.name`. Vaccination: `vaccine_name`, always populated regardless of `drug_source_value` |
+
+`drug_concept_id` / `drug_source_concept_id` (OMOP standard RxNorm / CVX),
+`route_concept_id`, and `drug_type_concept_id` are **not** emitted — see BL-003 and OQ-1.
+
+## Business logic
+
+- **BL-001:** The model is the `union all` of three branches — prescriptions (BL-006),
+  vaccinations (BL-007), and dispenses (BL-008) — sourced from `{{ ref('prescriptions') }}`,
+  `{{ ref('encounter_prescriptions') }}`, `{{ ref('reference_data') }}`,
+  `{{ ref('vaccine_administrations') }}`, `{{ ref('vaccine_schedules') }}`,
+  `{{ ref('medication_dispenses') }}`, `{{ ref('pharmacy_order_prescriptions') }}`,
+  `{{ ref('pharmacy_orders') }}`, and `{{ ref('encounters') }}` only (D10) — never `public.*`.
+  Soft-delete / test-patient
+  filtering is inherited from the base models; the branch PKs occupy disjoint id spaces so
+  `drug_exposure_id` is unique, and the joins are many-to-one, so grain is preserved.
+- **BL-002:** OMOP foreign keys are wired from the source row's encounter — `person_id` from
+  `patient_id`, `visit_occurrence_id` from `encounter_id`, and `provider_id` from the
+  prescriber / dispenser, or (vaccination) `coalesce(recorded_by_id, given_by)` — with ids
+  cast to `varchar` for a type-safe union. `person_id` and `visit_occurrence_id` always
+  resolve; `provider_id` only resolves to `ref__provider` for prescription/dispense rows,
+  since vaccination's `given_by` fallback is free text, not a user FK (AC-005 is scoped
+  accordingly).
+- **BL-003:** The Tamanu drug/vaccine is retained as `drug_source_value` (code) and
+  `drug_source_name`. `drug_concept_id` (RxNorm) and the vaccine CVX concept are **not**
+  emitted: mapping Tamanu drugs / vaccines to standard concepts needs the `vocab__` layer (D2),
+  not inline logic, and source code/name are retained so the concepts layer on later (OQ-1),
+  never replacing local values (D1).
+- **BL-004:** `drug_exposure_start_datetime` is when the exposure began — the prescription
+  `start_date` (falling back to `date`), the vaccination `date`, or the dispense
+  `dispensed_at`. `drug_exposure_end_datetime` is the prescription `end_date`; vaccinations and
+  dispenses are point events, so their end equals their start.
+- **BL-005:** `drug_exposure_type_source_value` records provenance and is the union
+  discriminator — `prescription`, `vaccination`, or `dispense` — with deployment extensions
+  carrying their own values.
+- **BL-006 (prescription branch):** Every `prescriptions` row is included, joined to its
+  encounter through `encounter_prescriptions` and to `reference_data` via `medication_id` for
+  the drug code/name — a plain id join, not filtered on `type = 'drug'`, since `medication_id`
+  only ever references a drug-type row by Tamanu's own referential convention. Discontinued
+  prescriptions are **kept** — the exposure still occurred — with `stop_reason` carrying
+  `discontinuing_reason`; `quantity`, `refills` (`repeats`), and `route` come from the
+  prescription.
+- **BL-007 (vaccination branch):** Only `vaccine_administrations` rows with `status = 'GIVEN'`
+  are included. `NOT_GIVEN` is not an exposure (it belongs in `clinical__observation`),
+  `RECORDED_IN_ERROR` is a deleted GIVEN, and `HISTORICAL` is a hidden shadow of a separate
+  GIVEN record — all three are excluded to avoid double-counting. `drug_source_name` is
+  always the row's own `vaccine_name`; `drug_source_value` is left-joined through
+  `scheduled_vaccine_id` → `vaccine_schedules` → `reference_data` and is NULL for
+  administrations not tied to a scheduled dose.
+- **BL-008 (dispense branch):** Every `medication_dispenses` row is included, reached through
+  `pharmacy_order_prescriptions` → `pharmacy_orders` for the encounter, and via
+  `pharmacy_order_prescriptions` → the originating `prescriptions` row (and `reference_data`)
+  for the drug identity. The dispenser is the dispense's own `dispensed_by_user_id`, not a
+  `pharmacy_orders` column. `quantity` is the dispensed quantity; `route` is inherited from
+  the prescription.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `drug_exposure_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `drug_exposure_id` is `unique` | grain | dbt `unique` |
+| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-002 | dbt `relationships` |
+| AC-004 | Every `visit_occurrence_id` exists in `clinical__visit_occurrence.visit_occurrence_id` | BL-002 | dbt `relationships` |
+| AC-005 | Every non-null `provider_id` on a `prescription`/`dispense` row exists in `ref__provider.provider_id` (vaccination excluded — `given_by` fallback is free text) | BL-002 | dbt `dbt_utils.relationships_where` |
+| AC-006 | `drug_exposure_start_datetime` is `not_null` | BL-004 | dbt `not_null` |
+| AC-007 | `drug_exposure_type_source_value` is one of `prescription` / `vaccination` / `dispense` | BL-005 | dbt `accepted_values` |
+| AC-008 | `drug_source_name` is `not_null` (every exposure names a drug/vaccine) | BL-003 | dbt `not_null` |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` / `derived__` artefacts get a `metric_definitions.csv` row.
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `prescriptions` | `bases/` | Prescription drug, prescriber, dose/route, dates, discontinuation (prescription branch) |
+| `encounter_prescriptions` | `bases/` | Links a prescription to its encounter (person + visit) |
+| `reference_data` | `bases/` | Drug code + name (`type = 'drug'`) for prescription / dispense branches |
+| `vaccine_administrations` | `bases/` | Vaccine event, status, `vaccine_name`, encounter, vaccinator (vaccination branch) |
+| `vaccine_schedules` | `bases/` | Resolves `scheduled_vaccine_id` to `reference_data.id` (vaccination branch's code) |
+| `medication_dispenses` | `bases/` | Dispensed quantity, datetime, dispenser (dispense branch) |
+| `pharmacy_order_prescriptions` | `bases/` | Links a dispense to its pharmacy order and originating prescription |
+| `pharmacy_orders` | `bases/` | Dispense encounter anchor |
+| `encounters` | `bases/` | Person (`patient_id`) via the source `encounter_id` |
+| `clinical__person` | `clinical/` | `person_id` FK target (AC-003) |
+| `clinical__visit_occurrence` | `clinical/` | `visit_occurrence_id` FK target (AC-004) |
+| `ref__provider` | `ref/` | `provider_id` FK target (AC-005) |
+
+## Open questions
+
+- **OQ-1:** `drug_concept_id` (RxNorm), the vaccine CVX concept, `route_concept_id`, and
+  `drug_type_concept_id` await a drug/vaccine map (D2) / the `vocab__` layer. Source
+  code/name are retained so the standard concepts can be layered on without reshaping.
+- **OQ-2:** `days_supply` and OMOP `drug_era` (collapsing prescriptions + dispenses into
+  continuous exposure eras) are out of scope for this canonical fact. Because prescriptions
+  and dispenses are both emitted (type-discriminated), a consumer counting exposures must
+  filter by `drug_exposure_type_source_value` to avoid counting the same medication twice —
+  to revisit if an era model is needed.


### PR DESCRIPTION
## Summary

Adds the OMOP-lite `DRUG_EXPOSURE` domain: one row per drug exposure, unioning three standard sources —

- **Prescriptions** — the clinical intent to treat: drug, prescriber, dose/route/frequency, dates, discontinuation trail. Discontinued prescriptions are **kept** (the exposure occurred), with `stop_reason` carrying why.
- **Vaccinations** — `vaccine_administrations` rows with `status = 'GIVEN'` only (`NOT_GIVEN`/`RECORDED_IN_ERROR`/`HISTORICAL` excluded to avoid double-counting). Drug code resolves via `scheduled_vaccine_id` → `vaccine_schedules` → `reference_data` when the dose is scheduled; `vaccine_name` is always retained as the name regardless.
- **Dispenses** — the physical hand-over of stock, reached through the pharmacy chain (`pharmacy_order_prescriptions` → `pharmacy_orders` for the encounter, and → the originating `prescriptions` row for drug identity, since a dispense carries no `medication_id` of its own).

`tamanu-source-dbt` is the standard model; a deployment recording additional drug sources extends `clinical__drug_exposure` in its own `tamanu-dbt-<deployment>` project.

Ships with:
- `models/clinical/clinical__drug_exposure.{sql,yml,md}`
- `specs/dbt-model/clinical__drug_exposure.md` — BL-001..008 anchored in SQL, AC-001..008 tested

## Notable design decision

Vaccination `provider_id` is `coalesce(recorded_by_id, given_by)` — `recorded_by_id` is a real user FK, but `given_by` is Tamanu free text ("not a requirement that the administerer is a Tamanu User" per source docs) used only as a fallback. Its FK relationship test is scoped off vaccination rows accordingly (`dbt_utils.relationships_where` with `from_condition`), matching this repo's existing pattern (`appointments.yml`, `certifiable_vaccines.yml`). Prescription and dispense rows keep the full FK guarantee.

## Why

Feeds the NCD hypertension/diabetes "on treatment" indicators (antihypertensives, metformin, etc.) and immunisation-coverage line-lists.

## Base branch

Based on `clinical-and-ref-models` (now including the merged `clinical__measurement`, #538): `main` doesn't yet have `ref__provider` or `clinical__visit_occurrence` (this model's FK targets).

## Test plan

- [x] `dbt parse` clean
- [x] Spec-anchor check (`.maui/scripts/check_spec_anchors.py`) — all BL-001..008 resolve to code anchors
- [x] Prescription branch validated against live Nauru demo data (3/3 rows, no fan-out, correct drug codes, `stop_reason` populated only on the discontinued row)
- [x] Dispense branch validated against live Syria demo data (50/50 rows through the 4-hop pharmacy chain, no fan-out, every row has a provider, real antihypertensives resolving correctly — ATENOLOL, BISOPROLOL)
- [x] `dbt test` / `sqlfluff` run clean (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)