### PR TITLE
fix(ci): allow github-actions bot in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -91,6 +91,9 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           prompt: "/review"
+          # PRs opened by automation (e.g. release/version-bump workflows) are authored by
+          # github-actions[bot]; allow that bot so the run is not rejected.
+          allowed_bots: "github-actions[bot]"
           claude_args: |
             --allowedTools "Read,Grep,Glob,Bash(gh pr *),Bash(gh api*),Bash(git diff*),Bash(git log*)"
             --append-system-prompt "Read ${{ steps.review.outputs.path }} and follow all instructions in it."


### PR DESCRIPTION
## Summary
- PRs opened by automation (e.g. release/version-bump workflows) are authored by `github-actions[bot]`, which `claude-code-action` rejects by default with "Workflow initiated by non-human actor".
- This repo's Claude Code Review workflow is an inlined copy of `beyondessential/maui-team`'s reusable workflow (a public repo can't call a reusable workflow in a private repo), kept manually in sync per the comment at the top of the file.
- The upstream copy in `.maui/.github/workflows/claude-code-review.yml` already had `allowed_bots: "github-actions[bot]"`; this syncs that fix into this repo's copy.

## Test plan
- [ ] Confirm the Claude Code Review workflow runs successfully on a PR opened by `github-actions[bot]` (e.g. a future version-bump PR)