### PR TITLE
fix(reports): avoid uuid/varchar operator ambiguity in facilityId comparisons (2.59.1)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: tamanu_source_dbt
-version: 2.59.0
+version: 2.59.1
 config-version: 2
 profile: tamanu_source_dbt
 

--- a/macros/reports/admissions_line_list.sql
+++ b/macros/reports/admissions_line_list.sql
@@ -34,7 +34,7 @@ where
         else {{ parameter('locationGroupId') }} = any(location_group_ids::text [])
     end
     and case when {{ parameter('facilityId') }} is null then true
-        else {{ parameter('facilityId') }} = facility_id
+        else facility_id = {{ parameter('facilityId') }}
     end
     and case when {{ parameter('departmentId') }} is null then true
         else {{ parameter('departmentId') }} = any(department_ids::text [])

--- a/models/reports/sql/sensitive/sensitive-prescription-line-list.sql
+++ b/models/reports/sql/sensitive/sensitive-prescription-line-list.sql
@@ -25,6 +25,6 @@ where
     {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('facilityId') }} is null then true
-        else {{ parameter('facilityId') }} = facility_id
+        else facility_id = {{ parameter('facilityId') }}
     end
 order by datetime desc

--- a/models/reports/sql/standard/prescription-line-list.sql
+++ b/models/reports/sql/standard/prescription-line-list.sql
@@ -25,6 +25,6 @@ where
     {{ to_user_selected_timezone('datetime') }} >= {{ parameter('fromDate', default_value='2024-01-01', data_type='date') }}
     and {{ to_user_selected_timezone('datetime') }} <= {{ parameter('toDate', default_value='2024-01-31', data_type='date') }}
     and case when {{ parameter('facilityId') }} is null then true
-        else {{ parameter('facilityId') }} = facility_id
+        else facility_id = {{ parameter('facilityId') }}
     end
 order by datetime desc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tamanu-source-dbt"
-version = "2.59.0"
+version = "2.59.1"
 description = "A dbt project that transforms Tamanu healthcare system data into optimised reporting datasets"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
Fixes an "invalid input syntax for type uuid" error on **Admissions line list** and **Prescription line list** (+ sensitive variant) when filtering by facility.

Tamanu's baseline schema defines a custom `= (uuid, character varying)` operator (`op_uuid_eq_varchar`) with no commutator. When a query compares an untyped string literal against a varchar column in that exact order (`{{ parameter('facilityId') }} = facility_id`), Postgres's operator resolution prefers coercing the literal to `uuid` to match that operator — which fails at runtime for any `facility_id` that isn't valid UUID syntax.

Flipping the comparison to put the column on the left (`facility_id = {{ parameter('facilityId') }}`) avoids the ambiguous operator entirely, matching the pattern already used by every other report that filters on `facilityId` (e.g. `medication-dispensed-summary`).

- **Admissions line list**: regression — lost an explicit `::text` cast that used to guard against this, in an earlier refactor (56680ec)
- **Prescription line list / sensitive prescription line list**: latent since these reports were introduced, never had the cast

Bumps version `2.59.0` → `2.59.1`.

## Test plan
- [ ] Verify `dbt compile` succeeds
- [ ] Run Admissions line list and Prescription line list with a non-UUID-shaped `facilityId` filter against a deployment where the `op_uuid_eq_varchar` operator is present, confirm no uuid error