### PR TITLE
fix(ci): auto-resolve version-only conflicts in forward-port cherry-picks

### DIFF
--- a/scripts/forwardport_patch.py
+++ b/scripts/forwardport_patch.py
@@ -139,6 +139,50 @@ def get_patch_commits(prev_tag: str, new_tag: str) -> list[str]:
     return [c for c in raw.splitlines() if c.strip()]
 
 
+VERSION_LINE_RE = re.compile(
+    r'^[+-](\s*version:\s*"?\d+\.\d+\.\d+"?\s*|\s*version\s*=\s*"\d+\.\d+\.\d+"\s*)$'
+)
+
+
+def is_version_only_diff(commit: str, filepath: str) -> bool:
+    """True if commit's diff for filepath touches only the version line."""
+    diff = git_out("show", commit, "--", filepath)
+    changed = [
+        line for line in diff.splitlines()
+        if line[:1] in ("+", "-") and not line.startswith(("+++", "---"))
+    ]
+    return bool(changed) and all(VERSION_LINE_RE.match(line) for line in changed)
+
+
+def get_unmerged_files() -> list[str]:
+    raw = git_out("diff", "--name-only", "--diff-filter=U")
+    return [f for f in raw.splitlines() if f.strip()]
+
+
+def try_autoresolve_version_conflict(commit: str) -> bool:
+    """Auto-resolve a cherry-pick conflict that is purely a version-line clash.
+
+    dbt_project.yml/pyproject.toml always conflict when cherry-picking a version
+    bump onto a branch already at a different version — the forward-port re-bumps
+    both files to the correct target version afterward regardless, so the incoming
+    change is always going to be overwritten. If every unmerged file is one of
+    VERSION_FILES and the commit's diff for it is only the version line, keep the
+    target branch's current content (git's "ours") and continue the cherry-pick.
+    Anything broader (other unmerged files, or extra changes bundled into a
+    version-file diff) is left for a human to resolve.
+    """
+    unmerged = get_unmerged_files()
+    if not unmerged or any(f not in VERSION_FILES for f in unmerged):
+        return False
+    if not all(is_version_only_diff(commit, f) for f in unmerged):
+        return False
+    for f in unmerged:
+        git("checkout", "--ours", f)
+        git("add", f)
+    result = git("-c", "core.editor=true", "cherry-pick", "--continue", check=False)
+    return result.returncode == 0
+
+
 # ---------------------------------------------------------------------------
 # Branch helpers
 # ---------------------------------------------------------------------------
@@ -233,6 +277,12 @@ def forwardport_to_branch(
                 git("cherry-pick", "--skip", check=False)
                 print(f"    ℹ️  Skipped already-applied commit {commit[:8]}")
                 already_applied_commits += 1
+                continue
+            if try_autoresolve_version_conflict(commit):
+                # Version-line-only clash in dbt_project.yml/pyproject.toml — the
+                # per-branch version bump below overwrites it correctly anyway.
+                print(f"    🔧 Auto-resolved version-file conflict in {commit[:8]}")
+                applied_commits += 1
                 continue
             # Real conflict — abort and open a draft PR with what we have so far
             git("cherry-pick", "--abort", check=False)

--- a/scripts/forwardport_patch.py
+++ b/scripts/forwardport_patch.py
@@ -140,6 +140,8 @@ def get_patch_commits(prev_tag: str, new_tag: str) -> list[str]:
 
 
 VERSION_LINE_RE = re.compile(
+    # dbt_project.yml: version: 2.50.4 or version: "2.50.4" (quotes optional in yaml)
+    # pyproject.toml: version = "2.50.4" (toml strings are always quoted)
     r'^[+-](\s*version:\s*"?\d+\.\d+\.\d+"?\s*|\s*version\s*=\s*"\d+\.\d+\.\d+"\s*)$'
 )
 
@@ -180,7 +182,48 @@ def try_autoresolve_version_conflict(commit: str) -> bool:
         git("checkout", "--ours", f)
         git("add", f)
     result = git("-c", "core.editor=true", "cherry-pick", "--continue", check=False)
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    # Keeping "ours" for every changed file can leave nothing to commit (e.g. a
+    # pure version-bump commit with no other content) — the version re-bump right
+    # after the cherry-pick loop covers this anyway, so treat it as resolved.
+    if "cherry-pick is now empty" in result.stdout + result.stderr:
+        skip_result = git("cherry-pick", "--skip", check=False)
+        return skip_result.returncode == 0
+    return False
+
+
+COMPILED_DIR = "compiled/"
+
+
+def strip_compiled_output_from_head() -> str:
+    """Drop any compiled/ changes the current HEAD commit carries, amending it.
+
+    compiled/ is version-stamped build output regenerated per release (e.g.
+    compiled/v2.54.17/...); forward-porting another branch's compiled artifacts
+    onto a different version line is never meaningful, so any compiled/ changes a
+    cherry-picked commit carries are dropped, keeping the rest of the commit intact.
+
+    Returns "stripped" if the commit still has other changes and was amended,
+    "dropped" if removing compiled/ left it empty and it was undone entirely, or
+    "" if the commit didn't touch compiled/ at all.
+    """
+    diff = git_out("diff", "--name-status", "HEAD~1", "HEAD", "--", COMPILED_DIR)
+    lines = [line for line in diff.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    for line in lines:
+        status, path = line.split("\t", 1)
+        if status.startswith("A"):
+            git("rm", "-f", "--", path)
+        else:
+            git("checkout", "HEAD~1", "--", path)
+    remaining = git_out("diff", "--cached", "--name-only", "HEAD~1")
+    if remaining.strip():
+        git("commit", "--amend", "--no-edit")
+        return "stripped"
+    git("reset", "--hard", "HEAD~1")
+    return "dropped"
 
 
 # ---------------------------------------------------------------------------
@@ -266,8 +309,19 @@ def forwardport_to_branch(
     # Cherry-pick patch commits
     applied_commits = 0
     already_applied_commits = 0
+    compiled_only_commits = 0
     conflict_commit = None
     conflict_index = None
+
+    def _handle_compiled_output(commit: str) -> None:
+        nonlocal compiled_only_commits
+        outcome = strip_compiled_output_from_head()
+        if outcome == "dropped":
+            print(f"    🧹 {commit[:8]} was compiled-output-only — dropped, nothing to forward-port")
+            compiled_only_commits += 1
+        elif outcome == "stripped":
+            print(f"    🧹 Dropped compiled/ output from {commit[:8]}")
+
     for i, commit in enumerate(patch_commits):
         result = git("cherry-pick", commit, check=False)
         if result.returncode != 0:
@@ -282,6 +336,7 @@ def forwardport_to_branch(
                 # Version-line-only clash in dbt_project.yml/pyproject.toml — the
                 # per-branch version bump below overwrites it correctly anyway.
                 print(f"    🔧 Auto-resolved version-file conflict in {commit[:8]}")
+                _handle_compiled_output(commit)
                 applied_commits += 1
                 continue
             # Real conflict — abort and open a draft PR with what we have so far
@@ -290,6 +345,7 @@ def forwardport_to_branch(
             conflict_index = i
             print(f"    ⚠️  Cherry-pick conflict at {commit[:8]}, will open draft PR")
             break
+        _handle_compiled_output(commit)
         applied_commits += 1
     applicable_commits = len(patch_commits) - already_applied_commits
 
@@ -337,10 +393,12 @@ def forwardport_to_branch(
         draft_args = ["--draft"]
     else:
         title = f"chore: forwardport {new_patch_tag} to {target_branch} (→ {new_target_version})"
-        skipped_note = (
-            f" ({already_applied_commits} already applied on this branch)"
-            if already_applied_commits else ""
-        )
+        skip_reasons = []
+        if already_applied_commits:
+            skip_reasons.append(f"{already_applied_commits} already applied on this branch")
+        if compiled_only_commits:
+            skip_reasons.append(f"{compiled_only_commits} were compiled-output-only")
+        skipped_note = f" ({', '.join(skip_reasons)})" if skip_reasons else ""
         body = (
             f"Forward-ports patch `{new_patch_tag}` (from `{source_major_minor}`) to `{target_branch}`.\n\n"
             f"- Bumps version `{target_version}` → `{new_target_version}`\n"

--- a/scripts/tests/test_forwardport_patch.py
+++ b/scripts/tests/test_forwardport_patch.py
@@ -15,6 +15,7 @@ from forwardport_patch import (
     get_unmerged_files,
     get_version_tags_for_minor_from_list,
     is_version_only_diff,
+    strip_compiled_output_from_head,
     try_autoresolve_version_conflict,
     update_version_in_files,
 )
@@ -442,6 +443,170 @@ def test_try_autoresolve_fails_when_diff_has_extra_changes():
 def test_try_autoresolve_fails_when_no_unmerged_files():
     with patch.object(forwardport_patch, "git_out", return_value=""):
         assert not try_autoresolve_version_conflict("b031e6c")
+
+
+def test_try_autoresolve_skips_when_continue_reports_empty():
+    # A pure version-bump commit: after keeping "ours" for both files, there's
+    # nothing left to commit, so `cherry-pick --continue` fails with "now empty".
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        if args[:2] == ("-c", "core.editor=true"):
+            m.returncode = 1
+            m.stdout = "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
+            m.stderr = ""
+        else:
+            m.returncode = 0
+            m.stdout = ""
+            m.stderr = ""
+        return m
+
+    def fake_git_out(*args):
+        if args[:2] == ("diff", "--name-only"):
+            return "dbt_project.yml"
+        return DBT_PROJECT_VERSION_DIFF
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        assert try_autoresolve_version_conflict("b031e6c")
+
+    assert ("cherry-pick", "--skip") in git_calls
+
+
+def test_try_autoresolve_fails_when_continue_fails_for_other_reason():
+    def fake_git(*args, **kwargs):
+        m = MagicMock()
+        if args[:2] == ("-c", "core.editor=true"):
+            m.returncode = 1
+            m.stdout = ""
+            m.stderr = "error: something else went wrong\n"
+        else:
+            m.returncode = 0
+        return m
+
+    def fake_git_out(*args):
+        if args[:2] == ("diff", "--name-only"):
+            return "dbt_project.yml"
+        return DBT_PROJECT_VERSION_DIFF
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        assert not try_autoresolve_version_conflict("b031e6c")
+
+
+# ---------------------------------------------------------------------------
+# strip_compiled_output_from_head
+# ---------------------------------------------------------------------------
+
+
+def test_strip_compiled_output_noop_when_nothing_touched():
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", return_value=""),
+    ):
+        assert strip_compiled_output_from_head() == ""
+    assert git_calls == []
+
+
+def test_strip_compiled_output_drops_commit_when_compiled_only():
+    # Everything the commit touched was under compiled/ — after removing it,
+    # nothing differs from the parent, so the whole commit is undone.
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    def fake_git_out(*args):
+        if args[:3] == ("diff", "--name-status", "HEAD~1"):
+            return "A\tcompiled/v2.54.17/foo.json\nA\tcompiled/v2.54.17/bar.json"
+        if args[:3] == ("diff", "--cached", "--name-only"):
+            return ""  # nothing left staged relative to HEAD~1
+        return ""
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        assert strip_compiled_output_from_head() == "dropped"
+
+    assert ("rm", "-f", "--", "compiled/v2.54.17/foo.json") in git_calls
+    assert ("rm", "-f", "--", "compiled/v2.54.17/bar.json") in git_calls
+    assert ("reset", "--hard", "HEAD~1") in git_calls
+    assert not any(c[0] == "commit" for c in git_calls)
+
+
+def test_strip_compiled_output_amends_when_other_changes_remain():
+    # Commit has both a compiled/ addition and a real dbt model change — keep the
+    # latter, drop the former, and amend rather than reset.
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    def fake_git_out(*args):
+        if args[:3] == ("diff", "--name-status", "HEAD~1"):
+            return "A\tcompiled/v2.54.17/foo.json"
+        if args[:3] == ("diff", "--cached", "--name-only"):
+            return "models/some_model.sql"  # still changes remaining after strip
+        return ""
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        assert strip_compiled_output_from_head() == "stripped"
+
+    assert ("rm", "-f", "--", "compiled/v2.54.17/foo.json") in git_calls
+    assert ("commit", "--amend", "--no-edit") in git_calls
+    assert not any(c[0] == "reset" for c in git_calls)
+
+
+def test_strip_compiled_output_restores_modified_not_removed():
+    # Modified (not added) compiled/ paths should be restored to HEAD~1's content
+    # via checkout, not `rm`.
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    def fake_git_out(*args):
+        if args[:3] == ("diff", "--name-status", "HEAD~1"):
+            return "M\tcompiled/v2.54.17/reporting-schema.sql"
+        if args[:3] == ("diff", "--cached", "--name-only"):
+            return ""
+        return ""
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        strip_compiled_output_from_head()
+
+    assert ("checkout", "HEAD~1", "--", "compiled/v2.54.17/reporting-schema.sql") in git_calls
+    assert not any(c[0] == "rm" for c in git_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_forwardport_patch.py
+++ b/scripts/tests/test_forwardport_patch.py
@@ -12,7 +12,10 @@ from forwardport_patch import (
     get_higher_minor_branches_from_list,
     get_major_minor_patch,
     get_previous_tag,
+    get_unmerged_files,
     get_version_tags_for_minor_from_list,
+    is_version_only_diff,
+    try_autoresolve_version_conflict,
     update_version_in_files,
 )
 
@@ -312,6 +315,133 @@ def test_update_version_overrides_wrong_version(tmp_path):
     finally:
         os.chdir(orig)
     assert "version: 2.50.5" in (tmp_path / "dbt_project.yml").read_text()
+
+
+# ---------------------------------------------------------------------------
+# is_version_only_diff / get_unmerged_files / try_autoresolve_version_conflict
+# ---------------------------------------------------------------------------
+
+DBT_PROJECT_VERSION_DIFF = textwrap.dedent("""\
+    diff --git a/dbt_project.yml b/dbt_project.yml
+    index b4a2a0d..e5bf381 100644
+    --- a/dbt_project.yml
+    +++ b/dbt_project.yml
+    @@ -1,5 +1,5 @@
+     name: tamanu_source_dbt
+    -version: 2.54.16
+    +version: 2.54.17
+     config-version: 2
+     profile: tamanu_source_dbt
+""")
+
+PYPROJECT_VERSION_DIFF = textwrap.dedent("""\
+    diff --git a/pyproject.toml b/pyproject.toml
+    index 477eae9..751f09a 100644
+    --- a/pyproject.toml
+    +++ b/pyproject.toml
+    @@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
+     [project]
+     name = "tamanu-source-dbt"
+    -version = "2.54.16"
+    +version = "2.54.17"
+     description = "..."
+""")
+
+DBT_PROJECT_MIXED_DIFF = textwrap.dedent("""\
+    diff --git a/dbt_project.yml b/dbt_project.yml
+    index b4a2a0d..e5bf381 100644
+    --- a/dbt_project.yml
+    +++ b/dbt_project.yml
+    @@ -1,5 +1,5 @@
+    -name: tamanu_source_dbt
+    +name: tamanu_source_dbt_renamed
+    -version: 2.54.16
+    +version: 2.54.17
+     config-version: 2
+     profile: tamanu_source_dbt
+""")
+
+
+def test_is_version_only_diff_dbt_project():
+    with patch.object(forwardport_patch, "git_out", return_value=DBT_PROJECT_VERSION_DIFF):
+        assert is_version_only_diff("b031e6c", "dbt_project.yml")
+
+
+def test_is_version_only_diff_pyproject():
+    with patch.object(forwardport_patch, "git_out", return_value=PYPROJECT_VERSION_DIFF):
+        assert is_version_only_diff("b031e6c", "pyproject.toml")
+
+
+def test_is_version_only_diff_false_when_other_lines_change():
+    with patch.object(forwardport_patch, "git_out", return_value=DBT_PROJECT_MIXED_DIFF):
+        assert not is_version_only_diff("b031e6c", "dbt_project.yml")
+
+
+def test_is_version_only_diff_false_when_no_diff():
+    with patch.object(forwardport_patch, "git_out", return_value=""):
+        assert not is_version_only_diff("b031e6c", "dbt_project.yml")
+
+
+def test_get_unmerged_files_parses_output():
+    with patch.object(forwardport_patch, "git_out", return_value="dbt_project.yml\npyproject.toml\n"):
+        assert get_unmerged_files() == ["dbt_project.yml", "pyproject.toml"]
+
+
+def test_get_unmerged_files_empty():
+    with patch.object(forwardport_patch, "git_out", return_value=""):
+        assert get_unmerged_files() == []
+
+
+def test_try_autoresolve_succeeds_on_version_only_conflict():
+    git_calls = []
+
+    def fake_git(*args, **kwargs):
+        git_calls.append(args)
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    def fake_git_out(*args):
+        if args[:2] == ("diff", "--name-only"):
+            return "dbt_project.yml\npyproject.toml"
+        if args[0] == "show":
+            return DBT_PROJECT_VERSION_DIFF if args[-1] == "dbt_project.yml" else PYPROJECT_VERSION_DIFF
+        return ""
+
+    with (
+        patch.object(forwardport_patch, "git", side_effect=fake_git),
+        patch.object(forwardport_patch, "git_out", side_effect=fake_git_out),
+    ):
+        assert try_autoresolve_version_conflict("b031e6c")
+
+    assert ("checkout", "--ours", "dbt_project.yml") in git_calls
+    assert ("checkout", "--ours", "pyproject.toml") in git_calls
+    assert ("-c", "core.editor=true", "cherry-pick", "--continue") in git_calls
+
+
+def test_try_autoresolve_fails_when_other_file_unmerged():
+    def fake_git_out(*args):
+        if args[:2] == ("diff", "--name-only"):
+            return "dbt_project.yml\ncompiled/reporting-schema.sql"
+        return DBT_PROJECT_VERSION_DIFF
+
+    with patch.object(forwardport_patch, "git_out", side_effect=fake_git_out):
+        assert not try_autoresolve_version_conflict("b031e6c")
+
+
+def test_try_autoresolve_fails_when_diff_has_extra_changes():
+    def fake_git_out(*args):
+        if args[:2] == ("diff", "--name-only"):
+            return "dbt_project.yml"
+        return DBT_PROJECT_MIXED_DIFF
+
+    with patch.object(forwardport_patch, "git_out", side_effect=fake_git_out):
+        assert not try_autoresolve_version_conflict("b031e6c")
+
+
+def test_try_autoresolve_fails_when_no_unmerged_files():
+    with patch.object(forwardport_patch, "git_out", return_value=""):
+        assert not try_autoresolve_version_conflict("b031e6c")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Every forward-port to date (v2.54.12, v2.54.17) has hit a manual-resolution conflict on the source branch's `release: bump version` commit
- That commit always edits `dbt_project.yml`/`pyproject.toml` to the *source* version, which always differs from whatever version the target branch is on — a structural, 100%-reproducible conflict
- The forward-port already re-bumps both files to the correct target version after the cherry-pick loop, so the incoming version-line edit is always going to be overwritten anyway
- Added `try_autoresolve_version_conflict()`: when a cherry-pick conflict's unmerged files are exactly `dbt_project.yml`/`pyproject.toml` *and* the commit's diff for each touches only the version line, keep the target's current content (`git checkout --ours`) and continue the cherry-pick, instead of aborting to a draft PR
- Anything broader (other unmerged files, or extra changes bundled into the version-file diff) still falls through to the existing abort-and-open-draft-PR path unchanged

### Follow-ups from review
- A pure version-bump commit (no other content) leaves nothing to commit once "ours" is kept for every conflicting file — `cherry-pick --continue` fails with "now empty" rather than succeeding. Now detected and resolved with `--skip` instead of falling through to the draft-PR path.
- `compiled/` is version-stamped build output regenerated per release; forward-porting another branch's compiled artifacts onto a different version line is never meaningful. Added `strip_compiled_output_from_head()`, which drops any `compiled/` changes a cherry-picked commit carries (amending the commit, or dropping it entirely if that was its only content), so only substantive changes land on the target branch.

## Test plan
- [x] `pytest scripts/tests/test_forwardport_patch.py` — 66/66 passing
- [x] Manually reproduced the real `b031e6cd` conflict (version-only) and confirmed auto-resolve + compiled/-stripping end-to-end in a scratch clone
- [ ] Next real forward-port with a release-bump commit in range should no longer open a draft PR, and should land with no `compiled/` files