### PR TITLE
feat(clinical): add clinical__observation (survey answers, social history, triage)

### DIFF
--- a/data_tests/data_test__clinical__observation.sql
+++ b/data_tests/data_test__clinical__observation.sql
@@ -1,0 +1,20 @@
+-- Singular tests for clinical__observation. One row per violation, tagged with the
+-- acceptance criterion it breaks. See specs/dbt-model/clinical__observation.md.
+
+with observation as (
+    select * from {{ ref('clinical__observation') }}
+),
+
+-- AC-008: every survey/triage row has a recorded value_source_value. Only a
+-- vaccination-not-given row may have a NULL value (the refusal itself is the fact,
+-- with or without a recorded reason) (BL-006, BL-008)
+ac_008 as (
+    select
+        observation_id,
+        'AC-008' as failed_ac
+    from observation
+    where value_source_value is null
+        and observation_type_source_value != 'vaccination not given'
+)
+
+select observation_id, failed_ac from ac_008

--- a/models/clinical/clinical__observation.md
+++ b/models/clinical/clinical__observation.md
@@ -1,0 +1,59 @@
+{% docs clinical__observation %}
+OMOP-lite OBSERVATION domain: one row per clinical fact that is neither a measurement nor a
+drug exposure, unioning program/referral-survey answers, vaccinations not given, and triage
+assessments. Carries the Tamanu observed fact as the source value with person/visit/provider
+foreign keys. observation_concept_id is deferred to the future vocab__ layer.
+Deployment-specific observation sources are added by per-deployment override.
+{% enddocs %}
+
+{% docs clinical__observation__observation_id %}
+Unique identifier for the observation; the OMOP observation_id (the survey_response_answers
+or administered_vaccines id, or a synthetic <triage_id>-<element> id for triage rows).
+{% enddocs %}
+
+{% docs clinical__observation__observation_date %}
+Date component of the observation datetime.
+{% enddocs %}
+
+{% docs clinical__observation__observation_datetime %}
+Timestamp at which the observation was recorded — the survey response start time, the
+vaccination-not-given time, or the triage time (the application-required triage moment).
+{% enddocs %}
+
+{% docs clinical__observation__observation_type_source_value %}
+Provenance of the observation: 'program survey' or 'referral survey' (survey answer),
+'vaccination not given' (a recorded refusal/not-done), or 'triage' (a triage element).
+Deployment-specific sources carry their own values when added by override.
+{% enddocs %}
+
+{% docs clinical__observation__value_as_number %}
+The observed value as a number, when it is numeric (e.g. a numeric survey answer, the triage
+score). NULL for non-numeric values and for vaccination-not-given rows.
+{% enddocs %}
+
+{% docs clinical__observation__value_source_value %}
+The recorded value as entered in Tamanu, retained verbatim — the survey answer, the
+not-given reason, or the triage element's value. NULL only for a vaccination-not-given row
+where no reason was recorded; the refusal itself is still the observation.
+{% enddocs %}
+
+{% docs clinical__observation__provider_id %}
+The user associated with the observation — the survey submitter, the triage clinician, or
+(for a not-given vaccination) the user who recorded it (recorded_by_id; not the free-text
+given_by, which may not reference a Tamanu user). FK to ref__provider for survey/triage rows.
+{% enddocs %}
+
+{% docs clinical__observation__visit_occurrence_id %}
+The encounter the observation was recorded on; the OMOP visit_occurrence_id. FK to
+clinical__visit_occurrence.
+{% enddocs %}
+
+{% docs clinical__observation__observation_source_value %}
+The Tamanu observed thing's code — the survey data element's code, the vaccine code
+(resolved via the scheduled vaccine, NULL if not scheduled), or the triage element key
+(triage_score, chief_complaint, secondary_complaint).
+{% enddocs %}
+
+{% docs clinical__observation__observation_source_name %}
+The observed thing's readable name, denormalised alongside the code.
+{% enddocs %}

--- a/models/clinical/clinical__observation.sql
+++ b/models/clinical/clinical__observation.sql
@@ -1,0 +1,184 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__observation -- OMOP-lite OBSERVATION domain. One row per clinical fact that is
+-- neither a measurement nor a drug exposure, unioning three standard sources:
+-- program/referral-survey answers (BL-006), vaccinations not given (BL-007), and triage
+-- assessments unpivoted from triages (BL-008, via int__triage_observations). The observed
+-- fact is retained as source code/name; FK graph wired from the encounter (BL-002);
+-- *_concept_id deferred to the future vocab__ layer (BL-003). Sources only from bases/ +
+-- intermediate (D10). Deployment-specific observation sources are added by per-deployment
+-- override (see spec). See spec for BL-001..BL-008.
+
+with survey_response_answers as (
+    select * from {{ ref('survey_response_answers') }}
+),
+
+survey_responses as (
+    select * from {{ ref('survey_responses') }}
+),
+
+surveys as (
+    select * from {{ ref('surveys') }}
+),
+
+program_data_elements as (
+    select * from {{ ref('program_data_elements') }}
+),
+
+vaccine_administrations as (
+    select * from {{ ref('vaccine_administrations') }}
+),
+
+vaccine_schedules as (
+    select * from {{ ref('vaccine_schedules') }}
+),
+
+reference_data as (
+    select * from {{ ref('reference_data') }}
+),
+
+triage_observations as (
+    select * from {{ ref('int__triage_observations') }}
+),
+
+encounters as (
+    select * from {{ ref('encounters') }}
+),
+
+-- every recorded answer to a programs/referral survey; sensitive surveys included, echo /
+-- non-answer question types excluded (BL-006)
+survey_answers as (
+    select
+        sra.id,
+        trim(sra.body) as body,
+        s.survey_type,
+        sr.encounter_id,
+        sr.start_datetime,
+        sr.submitted_by_id,
+        pde.code,
+        pde.name
+    from survey_response_answers sra
+    join survey_responses sr on sr.id = sra.response_id
+    join surveys s on s.id = sr.survey_id and s.survey_type in ('programs', 'referral')
+    join program_data_elements pde
+        on pde.id = sra.data_element_id
+        and pde.type not in ('PatientData', 'UserData', 'Instruction')
+    where sra.body is not null and trim(sra.body) != ''
+),
+
+-- survey branch (BL-006). ids cast to varchar so the union is type-safe (BL-002)
+survey_observations as (
+    select
+        sa.id::varchar           as observation_id,
+        e.patient_id::varchar    as person_id,
+        sa.start_datetime::date  as observation_date,
+        sa.start_datetime        as observation_datetime,
+        -- provenance / union discriminator (BL-005)
+        case sa.survey_type
+            when 'programs' then 'program survey'
+            else 'referral survey'
+        end                      as observation_type_source_value,
+        case when sa.body ~ '^-?[0-9]+(\.[0-9]+)?$' then sa.body::numeric end as value_as_number,
+        sa.body                  as value_source_value,
+        sa.submitted_by_id::varchar as provider_id,
+        sa.encounter_id::varchar as visit_occurrence_id,
+        sa.code as observation_source_value,
+        sa.name as observation_source_name
+    from survey_answers sa
+    join encounters e on e.id = sa.encounter_id
+),
+
+-- vaccination-not-given branch (BL-007): the refusal/not-done fact is the observation, so
+-- rows are kept even when no reason was recorded. Vaccine identity carried like
+-- clinical__drug_exposure: vaccine_name as the name, code via the scheduled vaccine
+not_given_observations as (
+    select
+        av.id::varchar        as observation_id,
+        e.patient_id::varchar as person_id,
+        av.datetime::date     as observation_date,
+        av.datetime           as observation_datetime,  -- when the not-given was recorded (BL-004)
+        'vaccination not given' as observation_type_source_value,
+        null::numeric         as value_as_number,
+        coalesce(rdr.name, av.reason) as value_source_value,
+        -- recorded_by_id (a real user FK) preferred; given_by is free text, so the FK test
+        -- is scoped off this branch (BL-002)
+        coalesce(av.recorded_by_id, av.given_by)::varchar as provider_id,
+        av.encounter_id::varchar as visit_occurrence_id,
+        rd.code         as observation_source_value,
+        av.vaccine_name as observation_source_name
+    from vaccine_administrations av
+    join encounters e on e.id = av.encounter_id
+    left join reference_data rdr on rdr.id = av.not_given_reason_id
+    left join vaccine_schedules vs on vs.id = av.scheduled_vaccine_id
+    left join reference_data rd on rd.id = vs.vaccine_id
+    where av.status = 'NOT_GIVEN'
+),
+
+-- triage branch, unpivoted upstream by int__triage_observations (BL-008). The synthetic
+-- id is <triage_id>-<element>, unique since each triage yields each element at most once
+triage_branch_observations as (
+    select
+        (t.triage_id || '-' || t.observation_source_value)::varchar as observation_id,
+        e.patient_id::varchar         as person_id,
+        t.observation_datetime::date  as observation_date,
+        t.observation_datetime        as observation_datetime,
+        'triage'                      as observation_type_source_value,
+        case when trim(t.value_source_value) ~ '^-?[0-9]+(\.[0-9]+)?$' then trim(t.value_source_value)::numeric end as value_as_number,
+        t.value_source_value          as value_source_value,
+        t.clinician_id::varchar       as provider_id,
+        t.encounter_id::varchar       as visit_occurrence_id,
+        t.observation_source_value    as observation_source_value,
+        t.observation_source_name     as observation_source_name
+    from triage_observations t
+    join encounters e on e.id = t.encounter_id
+)
+
+-- columns listed explicitly per branch so reordering one branch can't silently mis-map
+select
+    observation_id,
+    person_id,
+    observation_date,
+    observation_datetime,
+    observation_type_source_value,
+    value_as_number,
+    value_source_value,
+    provider_id,
+    visit_occurrence_id,
+    observation_source_value,
+    observation_source_name
+from survey_observations
+
+union all
+
+select
+    observation_id,
+    person_id,
+    observation_date,
+    observation_datetime,
+    observation_type_source_value,
+    value_as_number,
+    value_source_value,
+    provider_id,
+    visit_occurrence_id,
+    observation_source_value,
+    observation_source_name
+from not_given_observations
+
+union all
+
+select
+    observation_id,
+    person_id,
+    observation_date,
+    observation_datetime,
+    observation_type_source_value,
+    value_as_number,
+    value_source_value,
+    provider_id,
+    visit_occurrence_id,
+    observation_source_value,
+    observation_source_name
+from triage_branch_observations

--- a/models/clinical/clinical__observation.yml
+++ b/models/clinical/clinical__observation.yml
@@ -1,0 +1,83 @@
+version: 2
+
+models:
+  - name: clinical__observation
+    description: "{{ doc('clinical__observation') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: observation_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__observation_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__observation_observation_id_not_null
+          - unique:
+              name: ac_002_clinical__observation_observation_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('encounters__patient_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_003_clinical__observation_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: observation_date
+        data_type: date
+        description: "{{ doc('clinical__observation__observation_date') }}"
+      - name: observation_datetime
+        data_type: timestamp
+        description: "{{ doc('clinical__observation__observation_datetime') }}"
+        data_tests:
+          - not_null:
+              name: ac_006_clinical__observation_observation_datetime_not_null
+      - name: observation_type_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__observation_type_source_value') }}"
+        data_tests:
+          - accepted_values:
+              name: ac_007_clinical__observation_observation_type_source_value_accepted
+              arguments:
+                values:
+                  - program survey
+                  - referral survey
+                  - vaccination not given
+                  - triage
+      - name: value_as_number
+        data_type: numeric
+        description: "{{ doc('clinical__observation__value_as_number') }}"
+      - name: value_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__value_source_value') }}"
+      - name: provider_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__provider_id') }}"
+        data_tests:
+          - dbt_utils.relationships_where:
+              name: ac_005_clinical__observation_provider_id_in_ref__provider
+              arguments:
+                to: ref('ref__provider')
+                field: provider_id
+                from_condition: "observation_type_source_value != 'vaccination not given'"
+      - name: visit_occurrence_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__visit_occurrence_id') }}"
+        data_tests:
+          - relationships:
+              name: ac_004_clinical__observation_visit_occurrence_id_in_clinical__visit_occurrence
+              arguments:
+                to: ref('clinical__visit_occurrence')
+                field: visit_occurrence_id
+      - name: observation_source_value
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__observation_source_value') }}"
+      - name: observation_source_name
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation__observation_source_name') }}"

--- a/models/intermediate/standard/int__triage_observations.sql
+++ b/models/intermediate/standard/int__triage_observations.sql
@@ -1,0 +1,46 @@
+-- int__triage_observations -- unpivots the wide triages row into one row per recorded
+-- triage element (tall shape), for the triage branch of clinical__observation.
+-- Elements: the acuity score, and the chief/secondary complaints (resolved to their
+-- reference_data names, type = 'triageReason'). Blank/unrecorded elements are dropped.
+-- Values are kept as text here; the numeric cast happens in clinical__observation.
+
+with triages as (
+    select * from {{ ref('triages') }}
+),
+
+reference_data as (
+    select * from {{ ref('reference_data') }}
+),
+
+triage_elements as (
+    select
+        t.id as triage_id,
+        t.encounter_id,
+        t.clinician_id,
+        -- triage_time is application-required on the triage form, so it's the canonical
+        -- "when"; a null here is a data-quality issue AC-006 should surface, not paper over
+        t.triage_datetime as observation_datetime,
+        t.score,
+        cc.name as chief_complaint,
+        sc.name as secondary_complaint
+    from triages t
+    left join reference_data cc on cc.id = t.chief_complaint_id
+    left join reference_data sc on sc.id = t.secondary_complaint_id
+)
+
+-- one row per recorded element; blanks are dropped
+select
+    te.triage_id,
+    te.encounter_id,
+    te.clinician_id,
+    te.observation_datetime,
+    m.observation_source_value,
+    m.observation_source_name,
+    m.value_source_value
+from triage_elements te
+cross join lateral (values
+    ('triage_score',        'Triage score',        te.score),
+    ('chief_complaint',     'Chief complaint',     te.chief_complaint),
+    ('secondary_complaint', 'Secondary complaint', te.secondary_complaint)
+) as m (observation_source_value, observation_source_name, value_source_value)
+where m.value_source_value is not null and trim(m.value_source_value) != ''

--- a/specs/dbt-model/clinical__observation.md
+++ b/specs/dbt-model/clinical__observation.md
@@ -1,0 +1,191 @@
+# dbt Model Spec: `clinical__observation` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__observation` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `implemented` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-07-12 |
+| **Last updated** | 2026-07-12 |
+
+The OMOP-lite `OBSERVATION` domain — one row per clinical fact that is neither a measurement
+nor a drug exposure, unioning three standard sources: **program/referral-survey answers**
+(qualitative form responses), **vaccinations not given** (`status = 'NOT_GIVEN'`, with the
+reason as the value), and **triage assessments** (score and complaints, unpivoted). Each row
+carries the Tamanu source code/name and value with person / visit / provider foreign keys.
+Deployment-specific observation sources are a per-deployment extension. Completes the split
+started in `clinical__measurement` (BL-006: non-vitals survey answers belong here) and
+`clinical__drug_exposure` (BL-007: NOT_GIVEN belongs here). See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping, `vocab__`),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One row per observation in OMOP `OBSERVATION` shape: native
+UUID (or synthetic) PK, the observed fact retained as source code/name, the recorded value
+(numeric where quantitative, verbatim otherwise), the observation datetime, and the person /
+visit / provider foreign keys. OMOP's dividing line: `MEASUREMENT` holds values obtained by
+measuring (vitals, labs); `OBSERVATION` holds everything else clinically relevant — survey
+responses, refusal/not-done facts, assessments, social history.
+
+**Clinical context.** Three sources, unioned:
+- **Survey answers** — responses to `programs` and `referral` surveys (the Vitals survey feeds
+  `clinical__measurement` instead), one `survey_response_answer` per question, typed by its
+  `program_data_element`. Echo question types (`PatientData`, `UserData`) copy demographics
+  already canonical in `clinical__person`, and `Instruction` rows are not answers — excluded.
+- **Vaccinations not given** — `vaccine_administrations` rows with `status = 'NOT_GIVEN'`: a
+  refusal/not-done fact, not an exposure. The value is the not-given reason
+  (`not_given_reason_id` → `reference_data`, `type = 'vaccineNotGivenReason'`, falling back to
+  the free-text `reason`); the vaccine is the observed thing.
+- **Triage** — a `triages` row holds an acuity `score` plus chief/secondary complaints in
+  *wide* form. `int__triage_observations` unpivots it to one row per recorded element,
+  anchored to the triage's encounter and clinician.
+
+**Who reads it.** `derived__cohort_*` and `metric__` indicators that need qualitative facts —
+program-form flags (smoking status, risk factors), refusal reporting (vaccine hesitancy), and
+emergency-department triage acuity line-lists.
+
+**Standard model, deployment extension.** `tamanu-source-dbt` is the *standard* model: the
+survey branch captures *all* program/referral answers generically, with no deployment-specific
+data-element knowledge. A deployment that wants certain survey answers treated as measurements
+instead (e.g. BP captured in an NCD program form — see MAUI-6425) extends
+`clinical__measurement` in its `tamanu-dbt-<deployment>` project; see OQ-2 for the resulting
+overlap. This is by design; the standard model stays universal.
+
+## Grain
+
+**One row per:** recorded program/referral-survey answer (PK `survey_response_answers.id`),
+vaccination not given (PK `administered_vaccines.id`), or recorded triage element (synthetic
+PK `<triage_id>-<element>`), unioned. Only rows with a recorded fact are kept (BL-006,
+BL-008); NOT_GIVEN rows are kept even without a reason — the refusal itself is the fact
+(BL-007). The three id spaces are disjoint, so `observation_id` is unique; all joins are
+many-to-one, so grain is preserved.
+
+## Output schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `observation_id` | uuid or text | `survey_response_answers.id` (survey), `administered_vaccines.id` (not-given), or synthetic `<triage_id>-<element>` (triage). PK (D1) |
+| `person_id` | uuid | `encounters.patient_id` via the source's encounter. FK to `clinical__person.person_id` |
+| `observation_date` | date | Date component of the observation datetime |
+| `observation_datetime` | timestamp | Survey: response `start_datetime`. Not-given: `datetime`. Triage: `triage_time` (application-required) |
+| `observation_type_source_value` | text | `'program survey'`, `'referral survey'`, `'vaccination not given'`, or `'triage'` — provenance / union discriminator |
+| `value_as_number` | numeric | The value cast to numeric when numeric (e.g. triage score, numeric survey answers); NULL otherwise |
+| `value_source_value` | text | The recorded value verbatim — answer body, not-given reason, score, or complaint name. NULL only for a not-given row with no reason recorded |
+| `provider_id` | uuid or text | Survey: `submitted_by_id`. Not-given: `coalesce(recorded_by_id, given_by)`. Triage: `clinician_id`. FK to `ref__provider.provider_id` except not-given rows (AC-005) |
+| `visit_occurrence_id` | uuid | The source's `encounter_id`. FK to `clinical__visit_occurrence.visit_occurrence_id` |
+| `observation_source_value` | text | The observed thing's code — `program_data_elements.code`, the vaccine code (via schedule, else NULL), or the triage element key (`triage_score`, `chief_complaint`, `secondary_complaint`) |
+| `observation_source_name` | text | The observed thing's readable name — data-element name, `vaccine_name`, or the triage element label |
+
+`observation_concept_id` / `observation_source_concept_id`, `value_as_concept_id`, and
+`unit_concept_id` are **not** emitted — see BL-003 and OQ-1.
+
+## Business logic
+
+- **BL-001:** The model is the `union all` of three branches — survey answers (BL-006),
+  vaccinations not given (BL-007), and triage (BL-008) — sourced from
+  `{{ ref('survey_response_answers') }}`, `{{ ref('survey_responses') }}`,
+  `{{ ref('surveys') }}`, `{{ ref('program_data_elements') }}`,
+  `{{ ref('vaccine_administrations') }}`, `{{ ref('vaccine_schedules') }}`,
+  `{{ ref('reference_data') }}`, `{{ ref('int__triage_observations') }}`, and
+  `{{ ref('encounters') }}` only (D10) — never `public.*`. Soft-delete / test-patient
+  filtering is inherited from the base models; the branch PKs occupy disjoint id spaces so
+  `observation_id` is unique, and the joins are many-to-one, so grain is preserved.
+- **BL-002:** OMOP foreign keys are wired from the source row's encounter — `person_id` from
+  `patient_id`, `visit_occurrence_id` from `encounter_id`, and `provider_id` from the survey
+  submitter / triage clinician, or (not-given) `coalesce(recorded_by_id, given_by)` — with ids
+  cast to `varchar` for a type-safe union. `provider_id` only resolves to `ref__provider` for
+  survey/triage rows, since not-given's `given_by` fallback is free text, not a user FK
+  (AC-005 is scoped accordingly).
+- **BL-003:** The observed fact is retained as `observation_source_value` (code) and
+  `observation_source_name`; `observation_concept_id` and `value_as_concept_id` are **not**
+  emitted, since mapping Tamanu data elements / reasons / complaints to standard concepts
+  needs the `vocab__` layer (D2), never replacing local values (D1, OQ-1).
+- **BL-004:** `observation_datetime` is when the fact was recorded — the survey response
+  `start_datetime`, the vaccination-not-given `datetime`, or the triage's `triage_time`
+  (application-required, so the canonical triage moment). `observation_date` is its date
+  component.
+- **BL-005:** `observation_type_source_value` records provenance and is the union
+  discriminator — `program survey`, `referral survey`, `vaccination not given`, or `triage` —
+  with deployment extensions carrying their own values.
+- **BL-006 (survey branch):** Every answer with a recorded (non-blank) `body` to a survey with
+  `survey_type` in (`programs`, `referral`) is included — the Vitals survey feeds
+  `clinical__measurement` instead (its BL-006), and `obsolete` surveys are excluded. Sensitive
+  surveys (`is_sensitive`) are **included**: the `clinical__` layer is
+  `classification: restricted` throughout, matching sensitive lab-test types in
+  `clinical__measurement`. Echo / non-answer data-element types (`PatientData`, `UserData`,
+  `Instruction`) are excluded; numeric answers also populate `value_as_number` (same
+  signed-decimal pattern as `clinical__measurement` BL-003).
+- **BL-007 (vaccination-not-given branch):** Every `vaccine_administrations` row with
+  `status = 'NOT_GIVEN'` is included — the refusal/not-done fact is the observation, so rows
+  are kept even when no reason was recorded (`value_source_value` NULL). The value is the
+  not-given reason (`not_given_reason_id` → `reference_data.name`, falling back to the
+  free-text `reason`); the vaccine identity is carried like `clinical__drug_exposure` BL-007
+  (`vaccine_name` as the name; code via `scheduled_vaccine_id` → `vaccine_schedules` →
+  `reference_data` when scheduled, else NULL). The status enum also has forward-looking
+  values (`DUE`, `SCHEDULED`, `OVERDUE`, `UPCOMING`, `MISSED`, `UNKNOWN`) — these represent
+  schedule state, not a recorded clinical fact, and are surfaced by the separate
+  `upcoming_vaccinations` view rather than by rows here, so they're excluded.
+- **BL-008 (triage branch):** Triage assessments are unpivoted from the wide `triages` row by
+  `int__triage_observations` — one row per recorded element: `triage_score` (numeric, also in
+  `value_as_number`), `chief_complaint`, and `secondary_complaint` (complaint names resolved
+  from `reference_data` by id — an unfiltered join, since the complaint FKs only reference
+  `triageReason` rows), blanks dropped. The `observation_id` is
+  synthesised as `<triage_id>-<element>` (unique — one triage row per element), and the
+  unpivot lives in the int model to keep this model a clean union.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `observation_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `observation_id` is `unique` | grain | dbt `unique` |
+| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-002 | dbt `relationships` |
+| AC-004 | Every `visit_occurrence_id` exists in `clinical__visit_occurrence.visit_occurrence_id` | BL-002 | dbt `relationships` |
+| AC-005 | Every non-null `provider_id` on a survey/triage row exists in `ref__provider.provider_id` (not-given excluded — `given_by` fallback is free text) | BL-002 | dbt `dbt_utils.relationships_where` |
+| AC-006 | `observation_datetime` is `not_null` | BL-004 | dbt `not_null` |
+| AC-007 | `observation_type_source_value` is one of `program survey` / `referral survey` / `vaccination not given` / `triage` | BL-005 | dbt `accepted_values` |
+| AC-008 | Every survey/triage row has a non-null `value_source_value` (not-given rows may be NULL — the refusal is the fact) | BL-006, BL-008 | singular test |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` / `derived__` artefacts get a `metric_definitions.csv` row.
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `survey_response_answers` | `bases/` | The answer value (`body`) and its data-element FK (survey branch) |
+| `survey_responses` | `bases/` | Datetime, encounter (person + visit) anchor, submitter |
+| `surveys` | `bases/` | Restrict the survey branch to `survey_type` in (`programs`, `referral`) |
+| `program_data_elements` | `bases/` | The question (code + name + type, for the echo-type exclusion) |
+| `vaccine_administrations` | `bases/` | NOT_GIVEN rows, reason, `vaccine_name`, encounter, recorder |
+| `vaccine_schedules` | `bases/` | Resolves `scheduled_vaccine_id` to `reference_data.id` (vaccine code) |
+| `reference_data` | `bases/` | Not-given reason name (`type = 'vaccineNotGivenReason'`) and vaccine code |
+| `int__triage_observations` | `intermediate/` | Unpivots `triages` (+ `reference_data` complaints) into tall triage observations |
+| `encounters` | `bases/` | Person (`patient_id`) via the source `encounter_id` |
+| `clinical__person` | `clinical/` | `person_id` FK target (AC-003) |
+| `clinical__visit_occurrence` | `clinical/` | `visit_occurrence_id` FK target (AC-004) |
+| `ref__provider` | `ref/` | `provider_id` FK target (AC-005) |
+
+## Open questions
+
+- **OQ-1:** `observation_concept_id` (LOINC/SNOMED), `value_as_concept_id` (standard concepts
+  for answers/reasons/complaints), and `unit_concept_id` await the `vocab__` layer (D2).
+  Source code/name/value are retained so the standard concepts layer on without reshaping.
+- **OQ-2:** When a deployment reclassifies specific survey answers into its extended
+  `clinical__measurement` (e.g. NCD-form BP), those answers also appear here as observations —
+  a double representation. The deployment's override should exclude those data elements from
+  its `clinical__observation`; settle the mechanics with the first deployment that needs it.
+- **OQ-3:** Patient-level characteristics in `patient_additional_data` (`blood_type`,
+  `marital_status`, `educational_level`, occupation) are OMOP observations too. Add a fourth,
+  patient-level branch via an `int__patient_characteristic_observations` unpivot (the
+  `int__patient_birth_measurements` pattern) when a consumer needs them.


### PR DESCRIPTION
## What

Adds **`clinical__observation`** — the OMOP-lite `OBSERVATION` domain, and the last of the qualitative clinical facts. One row per observation, unioned from three sources:

- **program / referral survey answers** (non-answer question types excluded, sensitive surveys included)
- **vaccinations not given** (`status = 'NOT_GIVEN'`, kept without a reason — the refusal is the fact)
- **triage assessments** — chief/secondary complaint + triage score, unpivoted by a new `int__triage_observations` intermediate

OMOP-lite shape: source values retained, no concept shadows yet. Sources only from `bases/` (D10). Includes the SDD spec (`specs/dbt-model/clinical__observation.md`, status `implemented`) and a singular `value_source_value` test.

With this, the canonical set now covers person, visit_occurrence, visit_detail, condition_occurrence, measurement, drug_exposure, and observation — leaving only `clinical__observation_period`.

## Also in this branch

A second commit, `docs(spec): reconcile ACs and descriptions with implemented code`, tidies specs for already-merged models (ref__location AC-005, visit_occurrence AC-003, drug_exposure status, measurement wording, condition_occurrence provider_id doc block). It's cross-cutting rather than observation-specific — happy to split it into its own PR if you'd prefer this scoped to observation only.

## Validation

`dbt parse` clean; a spec-vs-code audit of the whole layer returned MATCH for observation. **Not yet run against a live replica** — `dbt build`/`test` still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)