### PR TITLE
docs(spec): reconcile ACs and descriptions with implemented code

### DIFF
--- a/models/clinical/clinical__condition_occurrence.yml
+++ b/models/clinical/clinical__condition_occurrence.yml
@@ -55,7 +55,7 @@ models:
         description: "{{ doc('clinical__condition_occurrence__is_primary') }}"
       - name: provider_id
         data_type: character varying(255)
-        description: "{{ doc('encounters__examiner_id') }}"
+        description: "{{ doc('encounter_diagnoses__clinician_id') }}"
         data_tests:
           - relationships:
               name: ac_005_clinical__condition_occurrence_provider_id_in_ref__provider

--- a/specs/dbt-model/clinical__drug_exposure.md
+++ b/specs/dbt-model/clinical__drug_exposure.md
@@ -8,7 +8,7 @@
 | **Type** | dbt model (canonical definition) |
 | **Layer** | `clinical` |
 | **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
-| **Status** | `draft` |
+| **Status** | `implemented` |
 | **Owner** | Maui team |
 | **Repo** | `tamanu-source-dbt` |
 | **Created** | 2026-07-09 |

--- a/specs/dbt-model/clinical__measurement.md
+++ b/specs/dbt-model/clinical__measurement.md
@@ -80,7 +80,7 @@ is preserved.
 | `measurement_datetime` | timestamp | Vitals: response `start_time`. Labs: `lab_tests.completed_datetime` (→ published/requested). Birth: birth datetime (→ registration date) |
 | `measurement_type_source_value` | text | `'vitals survey'`, `'lab'`, or `'birth data'` — provenance / union discriminator |
 | `value_as_number` | numeric | The value cast to numeric when numeric; **NULL for categorical results** (BL-003, BL-006, BL-007) |
-| `value_source_value` | text | The recorded value, retained verbatim. Always populated — the canonical value for categorical results |
+| `value_source_value` | text | The recorded value, whitespace-trimmed. Always populated — the canonical value for categorical results |
 | `unit_source_value` | text | Unit of measure. Labs: `lab_test_types.unit`. NULL for vitals (units implicit, not stored per answer) |
 | `provider_id` | uuid | Vitals: response submitter. Labs: requesting clinician. Birth: NULL (no user recorded). FK to `ref__provider.provider_id` |
 | `visit_occurrence_id` | uuid | The source's `encounter_id`; **NULL for birth measurements** (patient-level). FK to `clinical__visit_occurrence.visit_occurrence_id` |

--- a/specs/dbt-model/clinical__visit_occurrence.md
+++ b/specs/dbt-model/clinical__visit_occurrence.md
@@ -110,7 +110,7 @@ All joins in this model are many-to-one (encounter → map row), so grain is pre
 |---|---|---|---|
 | AC-001 | `visit_occurrence_id` is `not_null` | grain | dbt `not_null` |
 | AC-002 | `visit_occurrence_id` is `unique` | grain | dbt `unique` |
-| AC-003 | Every `person_id` exists in `clinical__person.person_id` | BL-001 | dbt `relationships` |
+| AC-003 | `person_id` is `not_null` and every value exists in `clinical__person.person_id` | BL-001 | dbt `not_null` + `relationships` |
 | AC-004 | Every non-null `visit_concept_id` exists in `map__omop_visit_type.concept_id` | BL-002 | dbt `relationships` |
 | AC-005 | `visit_type_concept_id` is `not_null` and always 32817 | BL-003 | dbt `not_null` + `accepted_values` |
 | AC-006 | `visit_start_datetime` is `not_null` | BL-004 | dbt `not_null` |

--- a/specs/dbt-model/ref__location.md
+++ b/specs/dbt-model/ref__location.md
@@ -95,6 +95,7 @@ used" principle, derived-elements-conventions § map__omop seeds).
 | AC-002 | `location_id` is `unique` (one row per village) | grain | dbt `unique` |
 | AC-003 | A village whose ancestry runs village → subdivision → division → country denormalises into one row with `city`, `county`, `state`, and `country_source_value` all populated | BL-003, BL-004 | dbt unit test (`test_ref__location_denormalises_full_hierarchy`) |
 | AC-004 | A level absent from a village's ancestry comes through NULL (e.g. parent is a division directly: `county` and `country_source_value` NULL, `state` populated) | BL-004 | dbt unit test (`test_ref__location_partial_hierarchy_yields_nulls`) |
+| AC-005 | An intermediate level (settlement) between a village and its subdivision is walked through, not dropped, so `county` still resolves from the subdivision above it | BL-002 | dbt unit test (`test_ref__location_walks_through_intermediate_settlement`) |
 
 ## Registry entry
 


### PR DESCRIPTION
## What

Documentation-only reconciliation of SDD specs against the already-merged models on this branch — no behaviour change. Findings came from a spec-vs-code audit of the whole canonical layer.

- **ref__location** — add **AC-005** documenting the intermediate-settlement-walk unit test (`test_ref__location_walks_through_intermediate_settlement`, BL-002).
- **clinical__visit_occurrence** — reword **AC-003** to cover the `person_id` `not_null` test (previously untied to any AC).
- **clinical__drug_exposure** — spec status `draft` → `implemented` (peers were already implemented).
- **clinical__measurement** — `value_source_value` described as "whitespace-trimmed" to match the code's `btrim` (was "verbatim").
- **clinical__condition_occurrence** — `provider_id` description now uses the `encounter_diagnoses__clinician_id` doc block (the diagnosing clinician) instead of the inaccurate `encounters__examiner_id`.

## Validation

`dbt parse` clean. Only a `.yml` doc-block reference and spec markdown changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)