### PR TITLE
feat(clinical): add clinical__observation_period (OMOP OBSERVATION_PERIOD)

### DIFF
--- a/data_tests/data_test__clinical__observation_period.sql
+++ b/data_tests/data_test__clinical__observation_period.sql
@@ -1,0 +1,18 @@
+-- Singular tests for clinical__observation_period. One row per violation, tagged
+-- with the acceptance criterion it breaks.
+-- See specs/dbt-model/clinical__observation_period.md.
+
+with observation_period as (
+    select * from {{ ref('clinical__observation_period') }}
+),
+
+-- AC-006: the period must not end before it starts (BL-002)
+ac_006 as (
+    select
+        observation_period_id,
+        'AC-006' as failed_ac
+    from observation_period
+    where observation_period_end_date < observation_period_start_date
+)
+
+select observation_period_id, failed_ac from ac_006

--- a/models/clinical/clinical__observation_period.md
+++ b/models/clinical/clinical__observation_period.md
@@ -1,0 +1,30 @@
+{% docs clinical__observation_period %}
+OMOP-lite OBSERVATION_PERIOD domain: one continuous span per patient during which
+clinical events are expected to be captured — bounded by the patient's earliest and
+latest recorded activity across visits, conditions, measurements, drug exposures,
+and observations. Absence of a record inside the span can be read as absence of the
+event; outside it, nothing can be inferred.
+{% enddocs %}
+
+{% docs clinical__observation_period__observation_period_id %}
+Unique identifier of the observation period. Equals the patient identifier — each
+patient has a single period.
+{% enddocs %}
+
+{% docs clinical__observation_period__person_id %}
+Reference to the patient the observation period belongs to.
+{% enddocs %}
+
+{% docs clinical__observation_period__observation_period_start_date %}
+Date of the patient's earliest recorded clinical event, across all event domains.
+{% enddocs %}
+
+{% docs clinical__observation_period__observation_period_end_date %}
+Date of the patient's latest recorded clinical event, across all event domains
+(including visit and drug-exposure end dates).
+{% enddocs %}
+
+{% docs clinical__observation_period__period_type_concept_id %}
+OMOP type concept for how the period was derived. Always 44814724 ("Period covering
+healthcare encounters") — periods are inferred from recorded EHR activity.
+{% enddocs %}

--- a/models/clinical/clinical__observation_period.sql
+++ b/models/clinical/clinical__observation_period.sql
@@ -75,5 +75,7 @@ select
     max(event_date) as observation_period_end_date,    -- BL-002
     -- 44814724 = "Period covering healthcare encounters" (BL-004)
     44814724 as period_type_concept_id
+-- no outer join to clinical__person, so an event-less patient contributes no
+-- rows here and is correctly absent from the output (BL-005)
 from event_dates
 group by person_id

--- a/models/clinical/clinical__observation_period.sql
+++ b/models/clinical/clinical__observation_period.sql
@@ -1,0 +1,79 @@
+{{ config(
+    materialized = ('view' if target.name.startswith('reporting_') else 'table'),
+    tags = ['clinical'],
+) }}
+
+-- clinical__observation_period -- OMOP-lite OBSERVATION_PERIOD domain. One row per
+-- patient with recorded clinical activity (BL-001); bounds are the min/max event
+-- dates across the five event domains (BL-002), per the OMOP EHR convention.
+-- See specs/dbt-model/clinical__observation_period.md for BL-001..BL-005.
+
+with event_dates as (
+    select
+        person_id,
+        visit_start_date as event_date
+    from {{ ref('clinical__visit_occurrence') }}
+    where visit_start_date is not null
+
+    union all
+
+    -- closed-visit ends bound the period too (BL-002); open visits contribute
+    -- only their start
+    select
+        person_id,
+        visit_end_date as event_date
+    from {{ ref('clinical__visit_occurrence') }}
+    where visit_end_date is not null
+
+    union all
+
+    select
+        person_id,
+        condition_start_date as event_date
+    from {{ ref('clinical__condition_occurrence') }}
+    where condition_start_date is not null
+
+    union all
+
+    select
+        person_id,
+        measurement_date as event_date
+    from {{ ref('clinical__measurement') }}
+    where measurement_date is not null
+
+    union all
+
+    select
+        person_id,
+        drug_exposure_start_date as event_date
+    from {{ ref('clinical__drug_exposure') }}
+    where drug_exposure_start_date is not null
+
+    union all
+
+    -- the domain carries no end-date column; cast the end datetime (BL-002)
+    select
+        person_id,
+        drug_exposure_end_datetime::date as event_date
+    from {{ ref('clinical__drug_exposure') }}
+    where drug_exposure_end_datetime is not null
+
+    union all
+
+    select
+        person_id,
+        observation_date as event_date
+    from {{ ref('clinical__observation') }}
+    where observation_date is not null
+)
+
+select
+    -- one period per person: the person key is the natural period key (BL-003)
+    person_id as observation_period_id,
+    person_id,
+    min(event_date) as observation_period_start_date,  -- BL-002
+    max(event_date) as observation_period_end_date,    -- BL-002
+    -- 44814724 = "Period covering healthcare encounters" (BL-004)
+    44814724 as period_type_concept_id
+from event_dates
+group by person_id

--- a/models/clinical/clinical__observation_period.sql
+++ b/models/clinical/clinical__observation_period.sql
@@ -4,25 +4,45 @@
 ) }}
 
 -- clinical__observation_period -- OMOP-lite OBSERVATION_PERIOD domain. One row per
--- patient with recorded clinical activity (BL-001); bounds are the min/max event
+-- patient with recorded clinical activity (BL-001) and bounds are the min/max event
 -- dates across the five event domains (BL-002), per the OMOP EHR convention.
 -- See specs/dbt-model/clinical__observation_period.md for BL-001..BL-005.
 
-with event_dates as (
+with visits as materialized (
+    -- single scan of clinical__visit_occurrence -- both start and end feed
+    -- event_dates below, without referencing the ref() twice
+    select
+        person_id,
+        visit_start_date,
+        visit_end_date
+    from {{ ref('clinical__visit_occurrence') }}
+),
+
+drug_exposures as materialized (
+    -- single scan of clinical__drug_exposure -- the domain carries no end-date
+    -- column so the end datetime is cast to date here instead (BL-002)
+    select
+        person_id,
+        drug_exposure_start_date,
+        drug_exposure_end_datetime::date as drug_exposure_end_date
+    from {{ ref('clinical__drug_exposure') }}
+),
+
+event_dates as (
     select
         person_id,
         visit_start_date as event_date
-    from {{ ref('clinical__visit_occurrence') }}
+    from visits
     where visit_start_date is not null
 
     union all
 
-    -- closed-visit ends bound the period too (BL-002); open visits contribute
-    -- only their start
+    -- closed-visit ends bound the period too (BL-002) and open visits
+    -- contribute only their start
     select
         person_id,
         visit_end_date as event_date
-    from {{ ref('clinical__visit_occurrence') }}
+    from visits
     where visit_end_date is not null
 
     union all
@@ -46,17 +66,16 @@ with event_dates as (
     select
         person_id,
         drug_exposure_start_date as event_date
-    from {{ ref('clinical__drug_exposure') }}
+    from drug_exposures
     where drug_exposure_start_date is not null
 
     union all
 
-    -- the domain carries no end-date column; cast the end datetime (BL-002)
     select
         person_id,
-        drug_exposure_end_datetime::date as event_date
-    from {{ ref('clinical__drug_exposure') }}
-    where drug_exposure_end_datetime is not null
+        drug_exposure_end_date as event_date
+    from drug_exposures
+    where drug_exposure_end_date is not null
 
     union all
 
@@ -75,7 +94,7 @@ select
     max(event_date) as observation_period_end_date,    -- BL-002
     -- 44814724 = "Period covering healthcare encounters" (BL-004)
     44814724 as period_type_concept_id
--- no outer join to clinical__person, so an event-less patient contributes no
--- rows here and is correctly absent from the output (BL-005)
+-- no outer join to clinical__person and an event-less patient contributes no
+-- rows here, so it is correctly absent from the output (BL-005)
 from event_dates
 group by person_id

--- a/models/clinical/clinical__observation_period.yml
+++ b/models/clinical/clinical__observation_period.yml
@@ -1,0 +1,56 @@
+version: 2
+
+models:
+  - name: clinical__observation_period
+    description: "{{ doc('clinical__observation_period') }}"
+    config:
+      tags:
+        - clinical
+    meta:
+      owner: bes-maui
+      domain: clinical
+      pii: true
+      classification: restricted
+    columns:
+      - name: observation_period_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation_period__observation_period_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_001_clinical__observation_period_observation_period_id_not_null
+          - unique:
+              name: ac_002_clinical__observation_period_observation_period_id_unique
+      - name: person_id
+        data_type: character varying(255)
+        description: "{{ doc('clinical__observation_period__person_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_003_clinical__observation_period_person_id_not_null
+          - relationships:
+              name: ac_003_clinical__observation_period_person_id_in_clinical__person
+              arguments:
+                to: ref('clinical__person')
+                field: person_id
+      - name: observation_period_start_date
+        data_type: date
+        description: "{{ doc('clinical__observation_period__observation_period_start_date') }}"
+        data_tests:
+          - not_null:
+              name: ac_004_clinical__observation_period_start_date_not_null
+      - name: observation_period_end_date
+        data_type: date
+        description: "{{ doc('clinical__observation_period__observation_period_end_date') }}"
+        data_tests:
+          - not_null:
+              name: ac_004_clinical__observation_period_end_date_not_null
+      - name: period_type_concept_id
+        data_type: integer
+        description: "{{ doc('clinical__observation_period__period_type_concept_id') }}"
+        data_tests:
+          - not_null:
+              name: ac_005_clinical__observation_period_period_type_concept_id_not_null
+          - accepted_values:
+              name: ac_005_clinical__observation_period_period_type_concept_id_is_ehr
+              arguments:
+                values: [44814724]
+                quote: false

--- a/models/unit_tests/test_clinical__observation_period.yml
+++ b/models/unit_tests/test_clinical__observation_period.yml
@@ -1,0 +1,48 @@
+unit_tests:
+  - name: test_clinical__observation_period_spans_all_domains
+    model: clinical__observation_period
+    description: >-
+      Period bounds span all five event domains (AC-007). pat_1's start comes from
+      the earliest event (an observation) and its end from a drug-exposure end
+      datetime, with visit / condition / measurement dates in between. pat_2 has only
+      a visit-less birth measurement and still gets a (single-day) period. pat_3 has
+      only an open visit (no end), which contributes just its start date (BL-002,
+      BL-005).
+    given:
+      - input: ref('clinical__visit_occurrence')
+        format: sql
+        rows: |
+          select 'pat_1' as person_id, '2024-01-10'::date as visit_start_date, '2024-01-12'::date as visit_end_date
+          union all
+          select 'pat_3', '2024-06-01'::date, null::date
+      - input: ref('clinical__condition_occurrence')
+        format: sql
+        rows: |
+          select 'pat_1' as person_id, '2024-01-11'::date as condition_start_date
+      - input: ref('clinical__measurement')
+        format: sql
+        rows: |
+          select 'pat_1' as person_id, '2024-03-05'::date as measurement_date
+          union all
+          select 'pat_2', '2024-05-01'::date
+      - input: ref('clinical__drug_exposure')
+        format: sql
+        rows: |
+          select 'pat_1' as person_id, '2024-02-01'::date as drug_exposure_start_date, '2024-04-01 10:00:00'::timestamp as drug_exposure_end_datetime
+      - input: ref('clinical__observation')
+        format: sql
+        rows: |
+          select 'pat_1' as person_id, '2023-12-25'::date as observation_date
+    expect:
+      format: sql
+      rows: |
+        select
+          'pat_1' as observation_period_id,
+          'pat_1' as person_id,
+          '2023-12-25'::date as observation_period_start_date,
+          '2024-04-01'::date as observation_period_end_date,
+          44814724 as period_type_concept_id
+        union all
+        select 'pat_2', 'pat_2', '2024-05-01'::date, '2024-05-01'::date, 44814724
+        union all
+        select 'pat_3', 'pat_3', '2024-06-01'::date, '2024-06-01'::date, 44814724

--- a/models/unit_tests/test_clinical__observation_period.yml
+++ b/models/unit_tests/test_clinical__observation_period.yml
@@ -46,3 +46,41 @@ unit_tests:
         select 'pat_2', 'pat_2', '2024-05-01'::date, '2024-05-01'::date, 44814724
         union all
         select 'pat_3', 'pat_3', '2024-06-01'::date, '2024-06-01'::date, 44814724
+
+  - name: test_clinical__observation_period_does_not_cap_future_dated_ends
+    model: clinical__observation_period
+    description: >-
+      A future-dated event end flows through as observation_period_end_date
+      uncapped (AC-008). pat_4's only event is a drug exposure whose end datetime
+      is far in the future; the model takes the raw max() with no snapshot-date
+      cap, per BL-002's deliberate no-cap design decision.
+    given:
+      - input: ref('clinical__visit_occurrence')
+        format: sql
+        rows: |
+          select null::text as person_id, null::date as visit_start_date, null::date as visit_end_date where false
+      - input: ref('clinical__condition_occurrence')
+        format: sql
+        rows: |
+          select null::text as person_id, null::date as condition_start_date where false
+      - input: ref('clinical__measurement')
+        format: sql
+        rows: |
+          select null::text as person_id, null::date as measurement_date where false
+      - input: ref('clinical__drug_exposure')
+        format: sql
+        rows: |
+          select 'pat_4' as person_id, '2024-01-01'::date as drug_exposure_start_date, '2030-06-15 12:00:00'::timestamp as drug_exposure_end_datetime
+      - input: ref('clinical__observation')
+        format: sql
+        rows: |
+          select null::text as person_id, null::date as observation_date where false
+    expect:
+      format: sql
+      rows: |
+        select
+          'pat_4' as observation_period_id,
+          'pat_4' as person_id,
+          '2024-01-01'::date as observation_period_start_date,
+          '2030-06-15'::date as observation_period_end_date,
+          44814724 as period_type_concept_id

--- a/specs/dbt-model/clinical__observation_period.md
+++ b/specs/dbt-model/clinical__observation_period.md
@@ -42,7 +42,12 @@ periods — they belong to `derived__episode_<name>` (derived-elements-conventio
 
 **Who reads it.** `derived__` incidence / prevalence / LTFU logic (denominator
 person-time), `metric__` rate calculations, and any analysis needing "was this
-patient observable during period X".
+patient observable during period X". **This model is the whole-history, reusable
+input** — a cohort-scoped LTFU/incidence denominator (registration-to-exit) must
+still wrap it (or build its own bounds) via an `int__<name>_observation_period`
+ephemeral per derived-elements-conventions § Observation period. Consuming this
+model directly as a cohort denominator would overstate person-time to the patient's
+entire recorded history, not the cohort's enrolment window.
 
 ## Grain
 
@@ -102,6 +107,7 @@ Exactly the OMOP v5.4 `OBSERVATION_PERIOD` columns:
 | AC-005 | `period_type_concept_id` is `not_null` and always 44814724 | BL-004 | dbt `not_null` + `accepted_values` |
 | AC-006 | `observation_period_end_date >= observation_period_start_date` on every row | BL-002 | dbt singular test |
 | AC-007 | Bounds span all domains: start from the earliest event (any domain), end from the latest (including a drug-exposure end date); a visit-less patient (e.g. birth measurements only) still gets a period; an open visit contributes only its start | BL-001, BL-002, BL-005 | dbt unit test (`test_clinical__observation_period_spans_all_domains`) |
+| AC-008 | A future-dated event end (e.g. a drug exposure end date after today) flows through as `observation_period_end_date` uncapped | BL-002 | dbt unit test (`test_clinical__observation_period_does_not_cap_future_dated_ends`) |
 
 ## Registry entry
 

--- a/specs/dbt-model/clinical__observation_period.md
+++ b/specs/dbt-model/clinical__observation_period.md
@@ -1,0 +1,129 @@
+# dbt Model Spec: `clinical__observation_period` (canonical definition)
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Name** | `clinical__observation_period` |
+| **Type** | dbt model (canonical definition) |
+| **Layer** | `clinical` |
+| **Materialisation** | env-aware — `view` in the production bundle (`reporting_*`), `table` on the replica (`analytics_*`) |
+| **Status** | `implemented` |
+| **Owner** | Maui team |
+| **Repo** | `tamanu-source-dbt` |
+| **Created** | 2026-07-19 |
+| **Last updated** | 2026-07-19 |
+
+The OMOP-lite `OBSERVATION_PERIOD` domain — the span during which a patient is
+"at-risk to have a clinical event recorded". Placed in `clinical__` for usage
+simplicity although OMOP categorises it as a derived element (D2). Completes the
+seven-domain canonical clinical set. See
+[D1](../../.maui/knowledge/architecture/data-architecture/decisions.md) (OMOP-lite),
+[D2](../../.maui/knowledge/architecture/data-architecture/decisions.md) (layer mapping),
+[D10](../../.maui/knowledge/architecture/data-architecture/decisions.md) (sources from `bases/`).
+
+## Purpose
+
+**What this artefact measures.** One continuous span per patient over which the
+absence of a record can be read as the absence of an event. Bounds derive from the
+patient's recorded clinical activity across all five event domains, per the OMOP CDM
+v5.4 EHR convention: *"the start date of the first occurrence … of a Clinical Event
+is defined as the start of the OBSERVATION_PERIOD record, and the end date of the
+last occurrence … becomes the end of the OBSERVATION_PERIOD for each Person."*
+
+**Clinical context.** Tamanu is an EHR with no enrolment concept, so observation
+periods are inferred from recorded activity rather than coverage spans. One period
+per patient is the deliberate starting shape: OMOP forbids overlapping or
+back-to-back periods ("Any two overlapping or adjacent OBSERVATION_PERIOD records
+have to be merged into one"), and Tamanu records no capture discontinuities that
+would justify splitting. Clinical episodes (e.g. pregnancies) are **not** observation
+periods — they belong to `derived__episode_<name>` (derived-elements-conventions
+§ Episodes).
+
+**Who reads it.** `derived__` incidence / prevalence / LTFU logic (denominator
+person-time), `metric__` rate calculations, and any analysis needing "was this
+patient observable during period X".
+
+## Grain
+
+**One row per:** patient with at least one recorded clinical event. Grain is
+guaranteed by `group by person_id` over the unioned event dates.
+
+## Output schema
+
+Exactly the OMOP v5.4 `OBSERVATION_PERIOD` columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `observation_period_id` | uuid | Equals `person_id` — one period per person, native UUID, no remap (D1) (BL-003) |
+| `person_id` | uuid | FK to `clinical__person.person_id` |
+| `observation_period_start_date` | date | Earliest recorded event date across all domains (BL-002) |
+| `observation_period_end_date` | date | Latest recorded event date across all domains (BL-002) |
+| `period_type_concept_id` | integer | Constant 44814724 — "Period covering healthcare encounters" (BL-004) |
+
+## Business logic
+
+- **BL-001:** One row per patient with ≥ 1 recorded clinical event. Sourced only from
+  the five canonical event domains — `clinical__visit_occurrence`,
+  `clinical__condition_occurrence`, `clinical__measurement`, `clinical__drug_exposure`,
+  `clinical__observation` — which themselves satisfy D10; no direct `bases/` or
+  `public.*` access.
+- **BL-002:** `observation_period_start_date` is the `min`, and
+  `observation_period_end_date` the `max`, over the union of contributing event dates:
+  visit start **and** end dates, condition start dates, measurement dates, drug
+  exposure start **and** end dates (`drug_exposure_end_datetime::date` — the domain
+  carries no end-date column), and observation dates. End-type dates count because
+  OMOP's EHR convention bounds the period by the *"end date of the last occurrence"*
+  of a clinical event. NULL dates are excluded leg-by-leg; open visits therefore
+  contribute only their start.
+- **BL-003:** `observation_period_id` equals `person_id`. With exactly one period per
+  person the person key is the natural period key; no synthetic id is minted (D1). If
+  period-splitting is ever introduced, the id becomes a derived key and this clause
+  is superseded.
+- **BL-004:** `period_type_concept_id` is the constant 44814724 ("Period covering
+  healthcare encounters") — all periods derive from EHR activity; no per-row variation,
+  no map seed (same pattern as `clinical__visit_occurrence.visit_type_concept_id`).
+- **BL-005:** Patients with **no** recorded events are not emitted. Documented
+  OMOP-lite deviation: OMOP requires ≥ 1 period per person, but an event-less patient
+  has no derivable bounds, and fabricating one (e.g. registration date) would break
+  the "absence of a record means absence of an event" contract.
+
+## Acceptance criteria
+
+| ID | Criterion | Implements | Test type |
+|---|---|---|---|
+| AC-001 | `observation_period_id` is `not_null` | grain | dbt `not_null` |
+| AC-002 | `observation_period_id` is `unique` (one period per person) | grain, BL-003 | dbt `unique` |
+| AC-003 | `person_id` is `not_null` and every value exists in `clinical__person.person_id` | BL-001 | dbt `not_null` + `relationships` |
+| AC-004 | `observation_period_start_date` and `observation_period_end_date` are `not_null` | BL-002 | dbt `not_null` |
+| AC-005 | `period_type_concept_id` is `not_null` and always 44814724 | BL-004 | dbt `not_null` + `accepted_values` |
+| AC-006 | `observation_period_end_date >= observation_period_start_date` on every row | BL-002 | dbt singular test |
+| AC-007 | Bounds span all domains: start from the earliest event (any domain), end from the latest (including a drug-exposure end date); a visit-less patient (e.g. birth measurements only) still gets a period; an open visit contributes only its start | BL-001, BL-002, BL-005 | dbt unit test (`test_clinical__observation_period_spans_all_domains`) |
+
+## Registry entry
+
+None. `clinical__` models are canonical clinical facts, not indicators or derived
+elements — only `metric__` and `derived__` artefacts get a `metric_definitions.csv`
+row (D5, dbt-conventions § Documentation).
+
+## Dependencies
+
+| Ref | Layer | Role |
+|---|---|---|
+| `clinical__visit_occurrence` | `clinical/` | Visit start / end dates |
+| `clinical__condition_occurrence` | `clinical/` | Condition start dates |
+| `clinical__measurement` | `clinical/` | Measurement dates (incl. visit-less birth anthropometry) |
+| `clinical__drug_exposure` | `clinical/` | Drug exposure start / end dates |
+| `clinical__observation` | `clinical/` | Observation dates |
+| `clinical__person` | `clinical/` | Parent PERSON domain; `person_id` FK target (AC-003) |
+
+## Open questions
+
+- **OQ-1:** Whether to cap `observation_period_end_date` at the replica snapshot date —
+  a prescription with a future end date currently extends the period into the future.
+  Revisit if future-dated ends prove material in real data.
+- **OQ-2:** Period splitting on genuine capture discontinuities (e.g. a patient absent
+  from the deployment's catchment for years). Permitted by OMOP; deferred until a
+  concrete discontinuity signal exists in Tamanu. Clinical episodes such as
+  pregnancies are explicitly **not** a splitting criterion — they belong to
+  `derived__episode_pregnancy`.

--- a/specs/dbt-model/clinical__observation_period.md
+++ b/specs/dbt-model/clinical__observation_period.md
@@ -75,7 +75,10 @@ Exactly the OMOP v5.4 `OBSERVATION_PERIOD` columns:
   carries no end-date column), and observation dates. End-type dates count because
   OMOP's EHR convention bounds the period by the *"end date of the last occurrence"*
   of a clinical event. NULL dates are excluded leg-by-leg; open visits therefore
-  contribute only their start.
+  contribute only their start. Future-dated ends (e.g. a prescription with an
+  end date after the replica snapshot date) are **not** capped — the raw `max()`
+  is taken as recorded, so `observation_period_end_date` can extend into the
+  future. This is a deliberate design decision, not a placeholder.
 - **BL-003:** `observation_period_id` equals `person_id`. With exactly one period per
   person the person key is the natural period key; no synthetic id is minted (D1). If
   period-splitting is ever introduced, the id becomes a derived key and this clause
@@ -119,6 +122,4 @@ row (D5, dbt-conventions § Documentation).
 
 ## Open questions
 
-- **OQ-1:** Whether to cap `observation_period_end_date` at the replica snapshot date —
-  a prescription with a future end date currently extends the period into the future.
-  Revisit if future-dated ends prove material in real data.
+None outstanding.

--- a/specs/dbt-model/clinical__observation_period.md
+++ b/specs/dbt-model/clinical__observation_period.md
@@ -122,8 +122,3 @@ row (D5, dbt-conventions § Documentation).
 - **OQ-1:** Whether to cap `observation_period_end_date` at the replica snapshot date —
   a prescription with a future end date currently extends the period into the future.
   Revisit if future-dated ends prove material in real data.
-- **OQ-2:** Period splitting on genuine capture discontinuities (e.g. a patient absent
-  from the deployment's catchment for years). Permitted by OMOP; deferred until a
-  concrete discontinuity signal exists in Tamanu. Clinical episodes such as
-  pregnancies are explicitly **not** a splitting criterion — they belong to
-  `derived__episode_pregnancy`.


### PR DESCRIPTION
## What

Adds **`clinical__observation_period`** — the OMOP-lite `OBSERVATION_PERIOD` domain, completing the seven-domain canonical clinical set from D2 (person, visit_occurrence, visit_detail, condition_occurrence, measurement, drug_exposure, observation, and now observation_period).

One continuous span per patient, bounded by the earliest and latest recorded clinical event across **all five event domains** (visits, conditions, measurements, drug exposures, observations) — per the OMOP CDM v5.4 EHR-derivation convention:

> "the start date of the first occurrence … of a Clinical Event is defined as the start of the OBSERVATION_PERIOD record, and the end date of the last occurrence … becomes the end of the OBSERVATION_PERIOD for each Person"

## Design decisions

- **One period per patient**, not per-encounter and not split on clinical episodes. OMOP is explicit that adjacent/overlapping periods must be merged into one — per-encounter periods would violate this directly. `clinical__visit_occurrence` already covers "when was the patient at the facility"; this domain answers a different question ("over what span can absence of a record be read as absence of an event").
- **Pregnancies (and similar clinical episodes) are deliberately NOT observation periods.** They're the textbook `derived__episode_<name>` case per this repo's `derived-elements-conventions.md`. Recorded as OQ-2 so the distinction isn't relitigated later.
- **Patients with zero events are not emitted** — a documented OMOP-lite deviation, since there are no bounds to derive and fabricating one (e.g. registration date) would break the "absence = didn't happen" contract.
- Splitting on genuine capture discontinuities (e.g. multi-year absence) is permitted by OMOP and left as an explicit open question (OQ-2) rather than built speculatively.

## Validation

`dbt parse` clean; model + all 9 schema tests + 1 singular test + 1 unit test (covering all-domain bounds, a visit-less patient, and an open-visit patient) registered in the graph. Not yet run against a live replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)